### PR TITLE
Implement Grid Layout, Change Header Alignment

### DIFF
--- a/components/Header.js
+++ b/components/Header.js
@@ -1,5 +1,6 @@
 import React, { useEffect, useRef } from "react";
 import styles from '../styles/components/Header.module.css';
+import { animated } from "react-spring";
 
 /**
  * @function random generates a random number between parameters min and max
@@ -14,7 +15,7 @@ const random = (min, max) => {
  * @param {*} param0
  * @returns
  */
-function Header({ title, size = null , style={}, interval = 3000 }) {
+function Header({ title, size = null , animateStyle={}, interval = 3000 }) {
     if (title.length > 25)
         size = '3rem';
     const ref = useRef();
@@ -28,8 +29,7 @@ function Header({ title, size = null , style={}, interval = 3000 }) {
 
     }, [])
 
-
-  return <div ref={ref} style={style} className={styles.gradient}>{title}</div>;
+  return <animated.div ref={ref} style={animateStyle} className={styles.gradient}>{title}</animated.div>;
 }
 
 export default Header;

--- a/pages/about/index.js
+++ b/pages/about/index.js
@@ -25,7 +25,7 @@ const index = ({source}) => {
           <meta name="twitter:card" content="summary_large_image"></meta>
           <link rel="icon" href="/favicon.ico" />
         </Head>
-        <main className={styles.main + ' main-body'}>
+        <main className={"flex flex-col pt-2 px-6 max-w-[50rem] align-center m-auto min-h-[600px] w-full"}>
           <Navbar/>
           <Header title={"About"}/>
           <AboutHero content={source}/>

--- a/pages/blog/index.js
+++ b/pages/blog/index.js
@@ -13,7 +13,7 @@ const index = ({ posts }) => {
     return (
         <>
        <HeadersCustom title={'Posts by Tag'}/>
-        <main className={styles.main + ' main-body'}>
+       <main className={"flex flex-col pt-2 px-6 max-w-[50rem] align-center m-auto min-h-[600px] w-full"}>
           <Navbar/>
           <Header title={"Blog"}/>
           <BlogList posts={posts}/>

--- a/pages/blog/posts/[slug]/index.js
+++ b/pages/blog/posts/[slug]/index.js
@@ -20,8 +20,11 @@ const PostPage = ({post}) => {
   return (
     <>
     <HeadersCustom title={post.meta.title} description={post.meta.excerpt}/>
-    <main className={styles.main + ' blog-body'}>
-      <Navbar/>
+    <main className={"flex flex-col pt-2 px-6 max-w-[50rem] align-center m-auto min-h-[600px] w-full"}>
+      <div className="w-full flex px-6">
+        <Navbar/>
+      </div>
+      
       <div style={{marginTop: '20px', width: '100%', height: '90px', backgroundPosition: 'cover', position: 'relative'}} className="">
         <div className='' style={
           {

--- a/pages/blog/tags/[slug].js
+++ b/pages/blog/tags/[slug].js
@@ -15,7 +15,7 @@ const PostPage = ({ slug, posts}) => {
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <link rel="icon" href="/favicon.ico" />
       </Head>
-      <main className={mainStyles.main + ' main-body'}>
+      <main className={"flex flex-col pt-2 px-6 max-w-[50rem] align-center m-auto min-h-[600px] w-full"}>
         <Navbar/>
         <Header title={slug ?? 'tag'} />
         <BlogList posts={posts}/>

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,52 +1,121 @@
-import Head from 'next/head'
-import Image from 'next/image'
+
 import { Inter } from '@next/font/google'
-import styles from '../styles/Home.module.css'
 import Navbar from '../components/Navbar'
 import Header from '../components/Header'
-import {tldr, Projects, Skills} from '../content/content.js'
-import { TLDR } from '../components/TLDR'
-import { ShmoveImages } from '../components/ShmoveImages'
 import { useContext, useEffect, useRef, useState } from 'react'
-import { Socials } from '../components/Socials'
-import HomeProjectsList from '../components/HomeProjectsList'
-import useIntersectionObserver from '../components/hooks/useIntersectionObserver'
-import { PageTransitionContext } from '../components/Context/PageTransitionContext'
-import BlogShortList from '../components/BlogShortList'
 import { getAllPostsSupa, getAllProjectsSupa } from './api'
 import SpotifyBubble from '../components/SpotifyBubble'
 import Footer from '../components/Footer';
-import LinkImage from '../public/link-image.png'
 import HeadersCustom from '../components/HeadersCustom'
+import { useSpring, useTrail, useTransition } from 'react-spring'
+import { animated } from 'react-spring'
 const inter = Inter({ subsets: ['latin'] })
 
 export default function Home({posts, projects}) {
-  
-  const [image, showImage] = useState(false);
-  const [showProjects, setShowProjects] = useState(false);
-  const [showBlogs, setShowBlogs] = useState(false);
-  const projectsRef = useRef(0);
-  const blogsRef = useRef(0);
-  const dataRef = useIntersectionObserver(projectsRef, {threshold: 0.25});
-  const blogRef = useIntersectionObserver(blogsRef, {threshold: 0.10});
 
-  useEffect(() => {
-    dataRef?.isIntersecting ? setShowProjects(true) : setShowProjects(false);
-    blogRef?.isIntersecting ? setShowBlogs(true): setShowBlogs(false)
-  }, [dataRef])
+  // TODO (@angel1254mc) change pageState useState to global context
+  const [headerSpring, headerApi] = useSpring(() => ({
+    from: {
+      opacity: 0,
+    },
+    to: {
+      opacity: 1
+    }
+  }))
+
+  const [trails, api] = useTrail(
+    13,
+    () => ({
+      from: { 
+        opacity: 0,
+        scale: 1.03,
+      },
+      to: {
+        opacity: 1,
+        scale: 1,
+      },
+      config: { mass: 5, tension: 2000, friction: 200 },
+      delay: 500,
+    })
+  )
+
+
+
   return (
     <div className="w-full flex flex-col items-center">
       <HeadersCustom/>
-      <main className={styles.main + ' main-body'}>
-        <Navbar/>
-        <div className={styles.animate_hero}>
-          <Header title={"Home"}/>
+      <main className="w-full flex flex-col items-center ">
+        <div className="w-full max-w-[50rem] flex flex-col justify-start py-2 px-6">
+          <Navbar/>
+          <Header animateStyle={headerSpring} title={"Home"}/>
+
+        </div>
+        {
+          /**
+           * <div className={styles.animate_hero}>
           <ShmoveImages openTrigger={image}/>
           <TLDR id="home-tldr" triggerImage={showImage} content={tldr} delay={100}/>
           <Socials openTrigger={image} delay={500} id={"awesome"}/>
         </div>
+           */
+        }
       </main>
-      <section className={styles.projects_and_blog}>
+      <div className="w-full px-8 flex justify-center">
+        <div className="w-full max-w-[50rem] h-auto flex flex-col gap-y-4">
+          <div className="w-full justify-center flex gap-x-4">
+            <animated.div style={trails[0]} className="flex flex-1 max-w-[24rem] h-96 bg-[#101010] rounded-md">
+              {/* Intro Box */}
+            </animated.div>
+            <div className="flex flex-1 max-w-[24rem] flex-col h-96 gap-y-4">
+              <animated.div  style={trails[1]}className="flex flex-1 w-full bg-[#101010] rounded-md"> 
+              {/* Work Expeerience Box */}
+              </animated.div>
+              <div className="flex flex-1 w-full gap-x-4">
+                <animated.div style={trails[2]} className="flex flex-1 h-full bg-[#101010] rounded-md">
+                  {/* Coffee Box 👁️🫦👁️ */}
+                </animated.div>
+                <animated.div style={trails[3]} className="flex flex-1 h-full bg-[#101010] rounded-md">
+                  {/* Last Starred Repo Box 👁️🫦👁️ */}
+                </animated.div>
+              </div>
+            </div>
+          </div>
+          <div className="w-full justify-center flex gap-x-4">
+            <div className="flex flex-col gap-y-4 flex-1 max-w-[24rem]">
+              <animated.div style={trails[4]} className="flex w-full h-44 bg-[#101010] rounded-md">
+                  {/* Spotify Box 👁️🫦👁️ */}
+              </animated.div>
+              <animated.h1 style={trails[7]} className="text-2xl font-bold">Peep The Rest</animated.h1>
+              <div className="flex w-full gap-x-4 h-44">
+                <animated.div style={trails[9]}  className="flex flex-1 h-full bg-[#101010] rounded-md">
+                  {/* SSD Box / Link to SSDiscord */}
+                </animated.div>
+                <animated.div style={trails[10]} className="flex flex-1 h-full bg-[#101010] rounded-md">
+                  {/* Twitch Box 👁️🫦👁️ */}
+                </animated.div>
+              </div>
+              <animated.div style={trails[12]} className="flex w-full gap-x-4 h-60 bg-[#101010] rounded-md">
+              </animated.div>
+            </div>
+            <div className="flex flex-col gap-y-4 flex-1 max-w-[24rem]">
+              <animated.h1 style={trails[5]} className="text-2xl font-bold">Peep The Blog</animated.h1>
+              <animated.div style={trails[6]} className="flex w-full h-48 bg-[#101010] rounded-md">
+                 {/* Latest Blog Post Box */}
+              </animated.div>
+              <animated.h1 style={trails[8]} className="text-2xl font-bold">Peep The Projects</animated.h1>
+              <animated.div style={trails[11]} className="flex w-full h-48 bg-[#101010] rounded-md">
+                {/* Most Relevant Project */}
+              </animated.div>
+              <animated.div style={trails[13]} className="flex w-full h-48 bg-[#101010] rounded-md">
+                {/* Second Most Relevant Project */}
+              </animated.div>
+            </div>
+          </div>
+        </div>
+      </div>
+        {/**
+         * 
+         * <section className={styles.projects_and_blog}>
         <div className={styles.projects_container}>
             <Header title={"Some of My Projects"} size={'2.5rem'}/>
             <HomeProjectsList projects={projects} dynamic={false} innerRef={projectsRef} open={showProjects}/>
@@ -61,6 +130,9 @@ export default function Home({posts, projects}) {
         
         <SpotifyBubble trigger={true}></SpotifyBubble>
       </section>
+         * 
+         * 
+         */}
       <Footer></Footer>
     </div>
   )

--- a/pages/projects/[slug].js
+++ b/pages/projects/[slug].js
@@ -20,7 +20,7 @@ const index = ({project, projectPosts}) => {
   return (
    <>
    <HeadersCustom title={`AngelFolio | ${project.name}`}/>
-    <main className={styles.main + ' main-body'}>
+    <main className={"flex flex-col pt-2 px-6 max-w-[50rem] align-center m-auto min-h-[600px] w-full"}>
       <Navbar/>
       <Header title={`Projects/${project.slug}`} size={'3rem'}/>
       {project?.accomplishments ? <MainAccomplishments accomplishments={project.accomplishments}/> : <></>}

--- a/pages/projects/index.js
+++ b/pages/projects/index.js
@@ -12,7 +12,7 @@ const index = ({ projects }) => {
     return (
         <>
         <HeadersCustom title={"AngelFolio | Projects"} description={"Some of my Projects"}/>
-        <main className={styles.main + ' main-body'}>
+        <main className={"flex flex-col pt-2 px-6 max-w-[50rem] align-center m-auto min-h-[600px] w-full"}>
           <Navbar/>
           <Header title={"Projects"}/>
           <ProjectList projects={projects}/>

--- a/styles/components/blog/BlogList.module.css
+++ b/styles/components/blog/BlogList.module.css
@@ -3,7 +3,7 @@
     flex-direction: column;
     align-items: center;
     row-gap: 15px;
-    max-width: 700px;
+    max-width: 100%;
     padding: 15px;
 }
 .post_container.unique:before {


### PR DESCRIPTION
### What this PR does/why we need it
This PR modifies the Home Layout to use the Grid (not really grid) layout displayed in #1. There's a fade-in animation for the grid layout, and sizes have already been set. All that's left is to make individual components for each block, and also adding some responsive CSS which can be done in a later PR.

### Issue this PR Fixes
This PR primarily deals with #2, but it also covers some header alignment changes that were not part of this ticket.

### Notes
Although this PR adds fade-in animations, fade-out animations are not added.