### PR TITLE
Implement Blog Post Component

### DIFF
--- a/components/Home/BlogPostComponent.js
+++ b/components/Home/BlogPostComponent.js
@@ -1,0 +1,36 @@
+import React from "react";
+import { useState } from "react";
+import { animated, useSpring } from "@react-spring/web";
+import Link from "next/link";
+import Image from "next/image";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faArrowRight } from "@fortawesome/free-solid-svg-icons";
+
+const BlogPostComponent = ({ latest = {} }) => {
+    const post = latest.meta;
+
+    return (
+        <Link
+            className="transition-all relative border-[1px] rounded-md border-[#101010] w-full duration-300 hover:shadow-[0px_0px_105px_3px_rgba(192,77,246,0.25)]"
+            href={`/blog/posts/${post.slug}`}
+        >
+            <Image fill={true} src={post.imageURI} alt={" image"} />
+            <div className="absolute flex flex-col justify-between h-full px-4 py-4 bg-[#101010] hover:shadow-inner shadow-2xl hover:bg-[rgba(16,16,16,0.7)] duration-300 transition-all z-50 w-full">
+                <div className="flex flex-col gap-y-2">
+                    <h1 className="text-xl font-bold">{post.title}</h1>
+                    <p className="text-sm font-light">{post.excerpt}</p>
+                </div>
+                <div className="flex justify-between text-sm">
+                    <p className="text-sm font-bold">
+                        {new Date(post.date).toLocaleDateString()}
+                    </p>
+                    <p className="text-sm flex gap-x-2 items-center py-1 px-2 font-semibold">
+                        See More <FontAwesomeIcon icon={faArrowRight} />
+                    </p>
+                </div>
+            </div>
+        </Link>
+    );
+};
+
+export default BlogPostComponent;

--- a/pages/index.js
+++ b/pages/index.js
@@ -14,6 +14,7 @@ import WorkComponent from '../components/Home/WorkComponent'
 import LastStarredRepo from '../components/Home/LastStarredRepo'
 import CoffeeComponent from '../components/Home/CoffeeComponent'
 import SpotifyComponent from '../components/Home/SpotifyComponent'
+import BlogPostComponent from '../components/Home/BlogPostComponent'
 const inter = Inter({ subsets: ['latin'] })
 
 export default function Home({posts, projects}) {
@@ -105,7 +106,7 @@ export default function Home({posts, projects}) {
             <div className="flex flex-col gap-y-4 flex-1 w-96 sm:max-w-[24rem]">
               <animated.h1 style={trails[6]} className="text-2xl font-bold">Peep The Blog</animated.h1>
               <animated.div style={trails[7]} className="flex w-full h-48 bg-[#101010] rounded-md">
-                 {/* Latest Blog Post Box */}
+                 <BlogPostComponent latest={posts[0]}/>
               </animated.div>
               <animated.h1 style={trails[9]} className="text-2xl font-bold">Peep The Projects</animated.h1>
               <animated.div style={trails[12]} className="flex w-full h-48 bg-[#101010] rounded-md">


### PR DESCRIPTION
### What this PR does/why we need it
This PR adds the Blog Post Component to the Home Page, which displays the most recent post on my blog. Instead of using the emoji + expanding background format, I fade the bg on hover to show the image that would have gone in the expanding background 👀 That way it doesn't take up as much space on the home page.

### Issue this PR Fixes
This PR fixes #14 

### Notes
I lowkey kinda like the idea of fading the background to show the image with a slight vignette. It feels new while still following the general theme established for blog cards on the blog page.