### PR TITLE
Make Certain Components Larger on Home Page

### DIFF
--- a/components/Home/CoffeeComponent.js
+++ b/components/Home/CoffeeComponent.js
@@ -58,8 +58,8 @@ const CoffeeComponent = () => {
             <FontAwesomeIcon className="text-6xl pl-2 pt-4" icon={faCoffee} />
             {showCoffee ? (
                 <div className="w-full pl-2 flex flex-wrap">
-                    <h1 id="last-drank" className="text-lg font-bold"></h1>
-                    <p className="text-base text-gray-400 font-iight">
+                    <h1 id="last-drank" className="text-lg 2xl:text-xl font-bold"></h1>
+                    <p className="text-base 2xl:text-lg text-gray-400 font-iight">
                         Without drinking Coffee
                     </p>
                 </div>

--- a/components/Home/IntroComponent.js
+++ b/components/Home/IntroComponent.js
@@ -78,7 +78,7 @@ const IntroComponent = () => {
                     rotateX: "180deg",
                 }}
                 onClick={() => setFlipped((state) => !state)}
-                className="card-container back h-96 w-96 rounded-md cursor-pointer"
+                className="card-container back h-96 2xl:h-[28rem] w-96 2xl:w-[28rem] rounded-md cursor-pointer"
             >
                 <div className="pt-3 pl-3 pb-3 w-full bg-black">
                     <Sheen>This is my dog Bella btw</Sheen>
@@ -98,10 +98,10 @@ const IntroComponent = () => {
                 >
                     <FontAwesomeIcon icon={faRepeat} />
                 </div>
-                <h1 className="text-2xl px-8 font-bold tracking-normal">
+                <h1 className="text-2xl 2xl:text-3xl px-8 font-bold tracking-normal">
                     Buenas!
                 </h1>
-                <div className="text-xs px-8 text-[#A19D9D]">
+                <div className="text-xs 2xl:text-sm px-8 text-[#A19D9D]">
                     <p className="flex flex-wrap">
                         {sequenceAnimation(firstParagraph, 0)}
                     </p>
@@ -121,12 +121,12 @@ const IntroComponent = () => {
                         )}
                     </p>
                 </div>
-                <div className="w-full pl-8 pt-2 flex gap-x-2">
+                <div className="w-full pl-8 pt-2 flex gap-x-2 2xl:gap-x-3">
                     <a
                         target="_blank"
                         rel="noreferrer"
                         href="https://github.com/angel1254mc/"
-                        className="w-7 h-7 hover:text-blue-300 text-2xl flex justify-center transition-all duration-100 cursor-pointer hover:text-3xl"
+                        className="w-7 h-7 2xl:text-3xl hover:text-blue-300 text-2xl flex justify-center transition-all duration-100 cursor-pointer hover:text-3xl"
                     >
                         <FontAwesomeIcon
                             style={{
@@ -142,7 +142,7 @@ const IntroComponent = () => {
                         target="_blank"
                         rel="noreferrer"
                         href="https://www.linkedin.com/in/angel1254/"
-                        className="w-7 h-7 hover:text-blue-300 text-2xl flex justify-center transition-all duration-100 cursor-pointer hover:text-3xl"
+                        className="w-7 h-7 2xl:text-3xl hover:text-blue-300 text-2xl flex justify-center transition-all duration-100 cursor-pointer hover:text-3xl"
                     >
                         <FontAwesomeIcon
                             style={{
@@ -156,7 +156,7 @@ const IntroComponent = () => {
                         target="_blank"
                         rel="noreferrer"
                         href="https://www.instagram.com/angel1254/"
-                        className="w-7 h-7 hover:text-blue-300 text-2xl flex justify-center transition-all duration-100 cursor-pointer hover:text-3xl"
+                        className="w-7 h-7 2xl:text-3xl hover:text-blue-300 text-2xl flex justify-center transition-all duration-100 cursor-pointer hover:text-3xl"
                     >
                         <FontAwesomeIcon
                             style={{
@@ -170,7 +170,7 @@ const IntroComponent = () => {
                         target="_blank"
                         rel="noreferrer"
                         href="https://www.youtube.com/channel/UC-kEszCPZTbWdRjt9RhVsYA"
-                        className="w-7 h-7 hover:text-blue-300 text-2xl flex justify-center transition-all duration-100 cursor-pointer hover:text-3xl"
+                        className="w-7 h-7 2xl:text-3xl hover:text-blue-300 text-2xl flex justify-center transition-all duration-100 cursor-pointer hover:text-3xl"
                     >
                         <FontAwesomeIcon
                             style={{

--- a/components/Home/LastStarredRepo.js
+++ b/components/Home/LastStarredRepo.js
@@ -45,10 +45,10 @@ const LastStarredRepo = () => {
             } rounded-md py-4 px-2 flex flex-col`}
             style={hoverAnimate}
         >
-            <div className="flex text-sm flex-wrap gap-x-2 gap-y-1 items-start">
+            <div className="flex text-sm 2xl:text-lg flex-wrap gap-x-2 gap-y-1 items-start">
                 <FontAwesomeIcon
                     icon={faStar}
-                    className=" text-purple-400 h-4 w-4"
+                    className=" text-purple-400 h-4 w-4  pt-1 2xl:h-5 2xl:w-5"
                 />
                 <h1 className="font-bold text-white">Last Starred Repo</h1>
             </div>
@@ -56,10 +56,10 @@ const LastStarredRepo = () => {
                 className="flex flex-col px-2 gap-y-1"
                 href={lastStarred?.url ? lastStarred.url : "/"}
             >
-                <h1 className="text-base font-light text-white underline">
+                <h1 className="text-base 2xl:text-xl font-light text-white underline">
                     {lastStarred?.full_name ? lastStarred.full_name : ""}
                 </h1>
-                <p className="text-xs text-gray-200 font-light text-overflow overflow-hidden max-h-[5rem]">
+                <p className="text-xs 2xl:text-sm text-gray-200 font-light text-overflow overflow-hidden max-h-[5rem] 2xl:max-h-[7.5rem]">
                     {lastStarred?.description
                         ? clampWords(removeEmojiColon(lastStarred.description))
                         : ""}

--- a/components/Home/WorkComponent.js
+++ b/components/Home/WorkComponent.js
@@ -11,46 +11,46 @@ const WorkComponent = () => {
     const [expanded, setExpanded] = useState(false);
     
   return (
-    <div className={`w-full rounded-md flex flex-col absolute hover:scale-[103%] hover:border-white bg-[#101010] h-full transition-all duration-150 overflow-y-hidden max-h-[24rem] border-2 z-10 ${!expanded ? 'sm:max-h-[11.5rem] sm:border-2 sm:border-transparent ' : 'sm:max-h-[24rem] border-2'}`}>
-        <div className="w-full text-xl font-bold pt-3 px-3 flex justify-between items-center">
+    <div className={`w-full rounded-md flex flex-col absolute hover:scale-[103%] hover:border-white bg-[#101010] h-full transition-all duration-150 overflow-y-hidden max-h-[24rem] border-2 z-10 ${!expanded ? 'md:max-h-[11.5rem] 2xl:max-h-[13.5rem] md:border-2 md:border-transparent ' : 'md:max-h-[24rem] 2xl:max-h-[28rem] border-2'}`}>
+        <div className="w-full text-xl 2xl:text-2xl font-bold pt-3 px-3 flex justify-between items-center">
             <h1>Where I&apos;ve Worked</h1>
             <button onClick={() => setExpanded(state => !state)}>
-                <FontAwesomeIcon className={`transition-all duration-150 text-xl sm:flex hidden text-gray-500 ${expanded ? "rotate-180" : ""}`} icon={faAngleDoubleDown} />
+                <FontAwesomeIcon className={`transition-all duration-150 text-xl 2xl:text-2xl md:flex hidden text-gray-500 ${expanded ? "rotate-180" : ""}`} icon={faAngleDoubleDown} />
             </button>
         </div>
         <div className="w-full flex flex-col h-full justify-between">
             <div className="flex flex-col w-full h-full gap-x-1 pt-1">
                 <div className="w-full flex gap-x-3 h-auto items-start">
-                    <FontAwesomeIcon className="text-[0.50rem] pt-[0.75rem] pl-4" icon={faCircle}/>
+                    <FontAwesomeIcon className="text-[0.50rem] pt-[0.75rem] 2xl:pt-[1rem] pl-4" icon={faCircle}/>
                     <div className="flex flex-col pt-1 flex-wrap gap-y-1">
-                        <h1 className="text-base font-semibold">Grafana Labs Inc.</h1>
-                        <p className="text-xs">Software Engineering Intern in the #infra-O11y squad</p>
-                        <p className="text-xs">May 2023 - Aug. 2023</p>
+                        <h1 className="text-base 2xl:text-xl font-semibold">Grafana Labs Inc.</h1>
+                        <p className="text-xs 2xl:text-sm">Software Engineering Intern in the #infra-O11y squad</p>
+                        <p className="text-xs 2xl:text-sm">May 2023 - Aug. 2023</p>
                         <div className="flex gap-x-4 items-center">
-                            <Link href="/about" className="text-xs py-1 mt-2 px-4 border-[1px] rounded-sm border-white">
-                                Read More <FontAwesomeIcon className="text-xs" icon={faAngleDoubleRight}/>
+                            <Link href="/about" className="py-1 mt-2 px-4 border-[1px] rounded-sm border-white">
+                                Read More <FontAwesomeIcon className="text-xs 2xl:text-sm" icon={faAngleDoubleRight}/>
                             </Link>
                             <Image className="w-7 h-7" width="92" height="72" loading="eager" src="/grafana-logo.png" />
                         </div>
                     </div>
                 </div>
 
-                <div className={`w-full pt-3 flex gap-x-3 h-auto items-start duration-150 ${expanded ? "sm:opacity-1" : "sm:opacity-0" }`}>
-                    <FontAwesomeIcon className="text-[0.50rem] pt-[0.75rem] pl-4" icon={faCircle}/>
+                <div className={`w-full pt-3 flex gap-x-3 h-auto items-start duration-150 ${expanded ? "md:opacity-1" : "md:opacity-0" }`}>
+                    <FontAwesomeIcon className="text-[0.50rem] pt-[0.75rem] 2xl:pt-[1rem] pl-4" icon={faCircle}/>
                     <div className="flex flex-col pt-1 flex-wrap gap-y-1">
-                        <h1 className="text-base font-semibold">Emerging Tech LLC</h1>
-                        <p className="text-xs">Associate Software Engineer</p>
-                        <p className="text-xs">May 2023 - Present</p>
+                        <h1 className="text-base 2xl:text-xl font-semibold">Emerging Tech LLC</h1>
+                        <p className="text-xs 2xl:text-sm">Associate Software Engineer</p>
+                        <p className="text-xs 2xl:text-sm">May 2023 - Present</p>
                         <div className="flex gap-x-4 items-center">
-                            <Link href="/about" className="text-xs py-1 mt-2 px-4 border-[1px] rounded-sm border-white">
-                                Read More <FontAwesomeIcon className="text-xs" icon={faAngleDoubleRight}/>
+                            <Link href="/about" className=" py-1 mt-2 px-4 border-[1px] rounded-sm border-white">
+                                Read More <FontAwesomeIcon className="text-xs 2xl:text-sm" icon={faAngleDoubleRight}/>
                             </Link>
                             <Image className="w-10 h-5" width="92" height="72" loading="eager" src="/et-logo.png" />
                         </div>
                     </div>
                 </div>
             </div>
-            <div className={`flex pb-8 text-sm px-4 h-auto items-start transition-all duration-150 ${ expanded ? "sm:opacity-1" : "sm:opacity-0" }`}>
+            <div className={`flex pb-8 text-sm 2xl:text-base px-4 h-auto items-start transition-all duration-150 ${ expanded ? "md:opacity-1" : "md:opacity-0" }`}>
                 <p>For more info on my past work experience, check out my <Sheen>LinkedIn</Sheen> or my <Sheen>About</Sheen> page!</p>
             </div>
             

--- a/pages/index.js
+++ b/pages/index.js
@@ -54,32 +54,23 @@ export default function Home({posts, projects}) {
     <div className="w-full flex flex-col items-center">
       <HeadersCustom/>
       <main className="w-full flex flex-col items-center ">
-        <div className="w-full max-w-[50rem] flex flex-col justify-start py-2 px-6">
+        <div className="w-full max-w-[50rem] 2xl:max-w-[64rem] flex flex-col justify-start py-2 px-6">
           <Navbar/>
           <Header animateStyle={headerSpring} title={"Home"}/>
 
         </div>
-        {
-          /**
-           * <div className={styles.animate_hero}>
-          <ShmoveImages openTrigger={image}/>
-          <TLDR id="home-tldr" triggerImage={showImage} content={tldr} delay={100}/>
-          <Socials openTrigger={image} delay={500} id={"awesome"}/>
-        </div>
-           */
-        }
       </main>
       <div className="w-full px-8 pb-6 flex justify-center">
-        <div className="w-full max-w-[50rem] h-auto flex flex-col gap-y-4">
-          <div className="w-full justify-center flex sm:flex-row flex-col sm:h-auto sm:min-h-[0] min-h-[48rem] gap-x-4 gap-y-4 items-center sm:items-start sm:gap-y-0">
-            <animated.div style={trails[0]} className="flex sm:flex-1 w-96 sm:max-w-[24rem] h-96 bg-[#101010] rounded-md">
+        <div className="w-full max-w-[50rem] 2xl:max-w-[64rem] h-auto flex flex-col gap-y-4">
+          <div className="w-full justify-center flex md:flex-row flex-col md:h-auto md:min-h-[0] min-h-[48rem] gap-x-4 gap-y-4 items-center md:items-start md:gap-y-0">
+            <animated.div style={trails[0]} className="flex md:flex-1 w-96 2xl:w-[28rem] md:max-w-[24rem] 2xl:max-w-[28rem] h-96 2xl:h-[28rem] bg-[#101010] rounded-md">
               <IntroComponent/>
             </animated.div>
-            <div className="flex sm:flex-1 w-96 sm:max-w-[24rem] flex-col relative sm:h-96 sm:min-h-0 min-h-[36rem] gap-y-4">
-              <animated.div  style={trails[1]}className="flex sm:flex-1 w-full h-96 bg-[#101010] rounded-md"> 
+            <div className="flex md:flex-1 w-96 md:max-w-[24rem] 2xl:w-[28rem] 2xl:max-w-[28rem] flex-col relative md:h-96  2xl:h-[28rem] md:min-h-0 min-h-[36rem] gap-y-4">
+              <animated.div  style={trails[1]}className="flex md:flex-1 w-full h-96 2xl:h-[28rem] bg-[#101010] rounded-md"> 
               <WorkComponent/>
               </animated.div>
-              <div className="flex h-[12rem] sm:h-auto sm:flex-1 w-full gap-x-4">
+              <div className="flex h-[12rem] md:h-auto md:flex-1 w-full gap-x-4">
                 <animated.div style={trails[2]} className="flex flex-1 h-full bg-[#101010] rounded-md">
                   <CoffeeComponent/>
                 </animated.div>
@@ -89,8 +80,8 @@ export default function Home({posts, projects}) {
               </div>
             </div>
           </div>
-          <div className="w-full items-center gap-y-4 sm:items-start sm:justify-center flex flex-col-reverse sm:flex-row gap-x-4">
-            <div className="flex flex-col gap-y-4 flex-1  w-96 sm:max-w-[24rem]">
+          <div className="w-full items-center gap-y-4 md:items-start md:justify-center flex flex-col-reverse md:flex-row gap-x-4">
+            <div className="flex flex-col gap-y-4 flex-1  w-96 md:max-w-[24rem]">
               <animated.h1 style={trails[4]} className="text-2xl font-bold">I&apos;m Listening To...</animated.h1>
               <animated.div style={trails[5]} className="flex w-full h-44 bg-[#101010] rounded-md">
                   <SpotifyComponent/>
@@ -108,7 +99,7 @@ export default function Home({posts, projects}) {
                 <FaroComponent/>
               </animated.div>
             </div>
-            <div className="flex flex-col gap-y-4 flex-1 w-96 sm:max-w-[24rem]">
+            <div className="flex flex-col gap-y-4 flex-1 w-96 md:max-w-[24rem]">
               <animated.h1 style={trails[6]} className="text-2xl font-bold">Peep The Blog</animated.h1>
               <animated.div style={trails[7]} className="flex w-full h-48 bg-[#101010] rounded-md">
                  <BlogPostComponent latest={posts[0]}/>
@@ -124,26 +115,6 @@ export default function Home({posts, projects}) {
           </div>
         </div>
       </div>
-        {/**
-         * 
-         * <section className={styles.projects_and_blog}>
-        <div className={styles.projects_container}>
-            <Header title={"Some of My Projects"} size={'2.5rem'}/>
-            <HomeProjectsList projects={projects} dynamic={false} innerRef={projectsRef} open={showProjects}/>
-        </div>
-        <div className={styles.blog_container}>
-          <Header title={"Latest Blog Posts"} size={'2.5rem'}/>
-          <BlogShortList dynamic={false} innerRef={blogsRef} open={showBlogs} posts={posts.map(post => post.meta)}/>
-        </div>
-      </section>
-      <section className={styles.spotify_container}>
-        <Header title={`If I'm listening to something, I'm not dead.`} style={{fontSize: '2.0rem'}} />
-        
-        <SpotifyBubble trigger={true}></SpotifyBubble>
-      </section>
-         * 
-         * 
-         */}
       <Footer></Footer>
     </div>
   )


### PR DESCRIPTION
### What this PR does / Why it's needed
This PR makes the text on certain components larger for bigger viewports (using 2xl: breakpoint). On larger monitors with 2k x 1k resolution, the text on the Intro Component looks a little grainy. These tailwind changes fix the grainyness.