### PR TITLE
[Bugfix] Force revalidate/no-cache for certain routes

### DIFF
--- a/src/components/Home/CoffeeComponent.js
+++ b/src/components/Home/CoffeeComponent.js
@@ -32,7 +32,9 @@ const CoffeeComponent = () => {
    };
 
    useEffect(() => {
-      fetch('/api/get-last-coffee-date')
+      fetch('/api/get-last-coffee-date', {
+         cache: 'no-store'
+      })
          .then((resp) => resp.json())
          .then((json) => {
             setShowCoffee(true);

--- a/src/components/Home/LastStarredRepo.js
+++ b/src/components/Home/LastStarredRepo.js
@@ -23,8 +23,9 @@ const LastStarredRepo = () => {
       return str.split(' ', 14).join(' ') + '...';
    };
    useEffect(() => {
-      fetch('/api/get-last-starred-repo')
-         .then((response) => {
+      fetch('/api/get-last-starred-repo',
+         { next: { revalidate: 60 } }
+      ).then((response) => {
             return response.json();
          })
          .then((json) => {

--- a/src/components/Home/SpotifyComponent.js
+++ b/src/components/Home/SpotifyComponent.js
@@ -40,7 +40,9 @@ const SpotifyComponent = () => {
    );
 
    const getCurrentlyPlaying = async () => {
-      const response = await fetch('/api/get-curr-playing');
+      const response = await fetch('/api/get-curr-playing',
+      { next: { revalidate: 60 } }
+      );
       const json = await response.json();
       setSpotifyObj(json);
    };


### PR DESCRIPTION
## What this PR does / Why it is needed
This PR forces routes like 'get-curr-playing', 'get-last-starred-repo',  and 'get-last-coffee-date' to either revalidate on an interval or not cache responses. This makes it so that things like the Spotify component receive concurrent data from the server in the production deployment.

## Notes
No notes 🥶