### PR TITLE
[Enhancement] - Refactored Faro Component

### DIFF
--- a/src/app/layout.js
+++ b/src/app/layout.js
@@ -2,7 +2,7 @@ import { Inter } from 'next/font/google';
 import './globals.css';
 import './prism-a11y-dark.css';
 import '@/components/Projects/ProjectList.css';
-import FaroContextProvider from '@/context/FaroContextProvider';
+import WebVitalsContextProvider from '@/context/WebVitalsContextProvider';
 
 const inter = Inter({ subsets: ['latin'] });
 
@@ -15,7 +15,7 @@ export default function RootLayout({ children }) {
    return (
       <html lang='en'>
          <body className={inter.className}>
-            <FaroContextProvider>{children}</FaroContextProvider>
+            <WebVitalsContextProvider>{children}</WebVitalsContextProvider>
          </body>
       </html>
    );

--- a/src/components/Admin/ProjectAuthor.js
+++ b/src/components/Admin/ProjectAuthor.js
@@ -53,6 +53,7 @@ const ProjectAuthor = ({ field, index, register, remove }) => {
                           src={pictureURL ?? '/profile-placeholder.webp'}
                           height={100}
                           width={100}
+                          alt={"Author Github"}
                           className='min-w-10 min-h-10 max-w-10 max-h-10 object-cover rounded-full'
                        ></Image>
                     </div>

--- a/src/components/BlogCard.js
+++ b/src/components/BlogCard.js
@@ -40,7 +40,7 @@ const BlogCard = ({ height, opacity, x, index, post }) => {
             className={blogCardStyles.notion_group}
          >
             <div className={blogCardStyles.post_emoji}>{post.emoji}</div>
-            <Image fill={true} src={post.imageURI} alt={' image'} />
+            <Image fill={true} src={post.imageURI} alt={'Blog Card Graphic'} />
          </animated.div>
          <div className='mt-6 p-4 text-2xl font-bold'>{post.title}</div>
          <div className='p-4 pt-2 text-lg'>{post.excerpt}</div>

--- a/src/components/Home/BlogPostComponent.js
+++ b/src/components/Home/BlogPostComponent.js
@@ -13,7 +13,7 @@ const BlogPostComponent = ({ latest = {} }) => {
          className='transition-all relative border-[1px] rounded-md border-[#101010] w-full duration-300 hover:scale-105 hover:shadow-[0px_0px_105px_3px_rgba(192,77,246,0.25)]'
          href={`/blog/posts/${post.slug}`}
       >
-         <Image fill={true} src={post.imageURI} alt={' image'} />
+         <Image fill={true} src={post.imageURI} alt={'Blog Post Graphic'} />
          <div className='absolute flex flex-col justify-between h-full px-4 py-4 bg-[#101010] hover:shadow-inner shadow-2xl hover:bg-[rgba(16,16,16,0.7)] duration-300 transition-all z-50 w-full'>
             <div className='flex flex-col gap-y-2'>
                <h1 className='text-xl font-bold'>{post.title}</h1>

--- a/src/components/Home/FaroComponent.js
+++ b/src/components/Home/FaroComponent.js
@@ -1,41 +1,27 @@
 'use client';
 import Image from 'next/image';
-import React from 'react';
+import React, { useRef } from 'react';
 import FaroImage from '../../../public/faro.webp';
 import { useEffect, useContext, useState } from 'react';
-import { onFID, onTTFB, onFCP, onCLS } from 'web-vitals';
-import FaroContext from '@/context/FaroContext';
+import WebVitalsContext from '@/context/WebVitalsContext';
 
 const FaroComponent = () => {
-   const { faroState } = useContext(FaroContext);
    const [webVitals, setWebVitals] = useState({});
    const [overallRating, setOverallRating] = useState('Loading...');
+   const webVitalsInterval = useRef(null);
+   const { webVitalsRef } = useContext(WebVitalsContext);
+   // One useEffect polls the overarching webVitalsContext to check for new data!
+   useEffect(() => {
+      if (!webVitalsInterval.current)
+         webVitalsInterval.current = setInterval(() => {
+            if (Object.keys(webVitalsRef.current) != Object.keys(webVitals))
+               setWebVitals({... webVitalsRef.current});
+         }, 1000)
+   }, [])
 
    useEffect(() => {
-      onFID((metric) => {
-         setWebVitals((state) => {
-            return { ...state, fid: metric };
-         });
-      });
-      onCLS((metric) => {
-         setWebVitals((state) => {
-            return { ...state, cls: metric };
-         });
-      });
-      onTTFB((metric) => {
-         setWebVitals((state) => {
-            return { ...state, ttfb: metric };
-         });
-      });
-      onFCP((metric) => {
-         setWebVitals((state) => {
-            return { ...state, fcp: metric };
-         });
-      });
-   }, []);
-
-   useEffect(() => {
-      if (webVitals.fid && webVitals.cls && webVitals.ttfb && webVitals.fcp) {
+      if (webVitals.FID && webVitals.CLS && webVitals.TTFB && webVitals.FCP) {
+         console.log("Pinged THe Overall Rating algo")
          let goodCounter = 0;
          let ratingArr = Object.keys(webVitals).map(
             (metric) => webVitals[metric].rating
@@ -47,9 +33,9 @@ const FaroComponent = () => {
          }
          if (goodCounter < 1) {
             setOverallRating('Bruh 💀');
-         } else if (goodCounter < 3) {
+         } else if (goodCounter < 4) {
             setOverallRating('Needs Improvement');
-         } else if (goodCounter == 4) {
+         } else if (goodCounter >= 4) {
             setOverallRating("Lookin' Good!");
          }
       }
@@ -63,6 +49,7 @@ const FaroComponent = () => {
                loading='eager'
                width={100}
                height={100}
+               alt={"Grafana Faro Logo"}
             />
             <div>
                <h1 className='text-sm font-bold'>Site Stats</h1>
@@ -79,64 +66,64 @@ const FaroComponent = () => {
                   <h3 className='text-sm font-bold'>TTFB</h3>
                   <p
                      className={`text-base font-bold pb-2 ${
-                        webVitals.ttfb
-                           ? webVitals?.ttfb?.rating == 'good'
+                        webVitals.TTFB
+                           ? webVitals?.TTFB?.rating == 'good'
                               ? 'text-green-500'
-                              : webVitals.ttfb.rating == 'poor'
+                              : webVitals.TTFB.rating == 'poor'
                                 ? 'text-red-400'
                                 : 'text-yellow-400'
                            : 'text-gray-400'
                      }`}
                   >
-                     {webVitals?.ttfb?.value?.toPrecision(5) ?? 'Loading...'}
+                     {webVitals?.TTFB?.value?.toPrecision(5) ?? 'Loading...'}
                   </p>
                </div>
                <div className='w-1/3 flex flex-col gap-y-1 items-center justify-center border-r-[1px] mb-2 border-r-[#1D1D1D] h-20'>
                   <h3 className='text-sm font-bold'>FCP</h3>
                   <p
                      className={`text-base font-bold pb-2 ${
-                        webVitals.fcp
-                           ? webVitals?.fcp?.rating == 'good'
+                        webVitals.FCP
+                           ? webVitals?.FCP?.rating == 'good'
                               ? 'text-green-500'
-                              : webVitals.fcp.rating == 'poor'
+                              : webVitals.FCP.rating == 'poor'
                                 ? 'text-red-400'
                                 : 'text-yellow-400'
                            : 'text-gray-400'
                      }`}
                   >
-                     {webVitals?.fcp?.value?.toPrecision(5) ?? 'Loading...'}
+                     {webVitals?.FCP?.value?.toPrecision(5) ?? 'Loading...'}
                   </p>
                </div>
                <div className='w-1/3 flex flex-col gap-y-1 items-center justify-center h-20 mb-2'>
                   <h3 className='text-sm font-bold'>FID</h3>
                   <p
                      className={`text-base font-bold pb-2 ${
-                        webVitals.fid
-                           ? webVitals?.fid?.rating == 'good'
+                        webVitals.FID
+                           ? webVitals?.FID?.rating == 'good'
                               ? 'text-green-500'
-                              : webVitals.fid.rating == 'poor'
+                              : webVitals.FID.rating == 'poor'
                                 ? 'text-red-400'
                                 : 'text-yellow-400'
                            : 'text-gray-400'
                      }`}
                   >
-                     {webVitals?.fid?.value?.toPrecision(5) ?? 'Loading...'}
+                     {webVitals?.FID?.value?.toPrecision(5) ?? 'Loading...'}
                   </p>
                </div>
                <div className='w-1/3 flex flex-col gap-y-1 items-center justify-center mb-2 border-r-[1px] border-r-[#1D1D1D] h-20'>
                   <h3 className='text-sm font-bold'>CLS</h3>
                   <p
                      className={`text-base font-bold pb-2 ${
-                        webVitals.cls
-                           ? webVitals?.cls?.rating == 'good'
+                        webVitals.CLS
+                           ? webVitals?.CLS?.rating == 'good'
                               ? 'text-green-500'
-                              : webVitals.cls.rating == 'poor'
+                              : webVitals.CLS.rating == 'poor'
                                 ? 'text-red-400'
                                 : 'text-yellow-400'
                            : 'text-gray-400'
                      }`}
                   >
-                     {webVitals?.cls?.value?.toPrecision(5) ?? 'Loading...'}
+                     {webVitals?.CLS?.value?.toPrecision(5) ?? 'Loading...'}
                   </p>
                </div>
                <div className='w-2/3 flex flex-col gap-y-1 items-center justify-center h-20 mb-2'>

--- a/src/components/Home/SSDComponent.js
+++ b/src/components/Home/SSDComponent.js
@@ -15,6 +15,7 @@ const SSDComponent = () => {
                loading='eager'
                width={'50'}
                height={'50'}
+               alt={"Society of Software Developers Logo"}
             />
             <a
                className='text-lg transition-all duration-300 hover:rotate-[360deg] hover:text-blue-300'

--- a/src/components/Home/SpotifyComponent.js
+++ b/src/components/Home/SpotifyComponent.js
@@ -20,7 +20,7 @@ const SpotifyComponent = () => {
                return (
                   <a
                      href={artistObj?.external_urls?.spotify ?? ''}
-                     key={artistObj.id}
+                     key={artistObj.id ? artistObj.id : `some-artist-${index}`}
                   >
                      {artistObj.name}
                   </a>
@@ -79,6 +79,7 @@ const SpotifyComponent = () => {
                   className='w-28 h-28'
                   width={200}
                   height={200}
+                  alt={spotifyObj?.item?.name ? spotifyObj.item.name : "Placeholder for no Spotify Songs" }
                   src={
                      spotifyObj && spotifyObj.item
                         ? spotifyObj?.item?.album?.images[0]?.url

--- a/src/components/Home/WorkComponent.js
+++ b/src/components/Home/WorkComponent.js
@@ -64,6 +64,7 @@ const WorkComponent = () => {
                            height='72'
                            loading='eager'
                            src='/grafana-logo.png'
+                           alt="Grafana Labs Inc Logo"
                         />
                      </div>
                   </div>
@@ -103,6 +104,7 @@ const WorkComponent = () => {
                            height='72'
                            loading='eager'
                            src='/et-logo.png'
+                           alt='Emerging Tech LLC Logo'
                         />
                      </div>
                   </div>

--- a/src/components/SpotifyBubble/SpotifyBubble.js
+++ b/src/components/SpotifyBubble/SpotifyBubble.js
@@ -76,6 +76,7 @@ const SpotifyBubble = ({ trigger }) => {
                         ? spotifyObj?.item?.album?.images[0]?.url
                         : cover
                   }
+                  alt="Spotify Album Image"
                />
                <div className={styles.spotify_data_container}>
                   <div className={styles.spotify_song_title}>

--- a/src/context/WebVitalsContext.js
+++ b/src/context/WebVitalsContext.js
@@ -1,0 +1,6 @@
+import React from 'react';
+
+// This will create both a Context object with a Provider and Consumer.
+const WebVitalsContext = React.createContext();
+
+export default WebVitalsContext;

--- a/src/context/WebVitalsContextProvider.js
+++ b/src/context/WebVitalsContextProvider.js
@@ -1,0 +1,23 @@
+'use client';
+import React, { useRef } from 'react';
+import WebVitalsContext from './WebVitalsContext';
+import { useReportWebVitals } from 'next/web-vitals';
+
+const WebVitalsContextProvider = ({ children }) => {
+   const webVitalsRef = useRef(null);
+   
+   useReportWebVitals((metric) => {
+    console.log(metric);
+    let newState = { ... webVitalsRef.current };
+    newState[metric.name] = metric;
+    webVitalsRef.current = newState;
+   })
+
+   return (
+      <WebVitalsContext.Provider value={{ webVitalsRef }}>
+         {children}
+      </WebVitalsContext.Provider>
+   );
+};
+
+export default WebVitalsContextProvider;


### PR DESCRIPTION
## What this PR does / Why it is needed
This PR refactors the Faro Component by swapping out its use of `onFCP`, `onCLS`, `onFID`,  and so on with a single call to `useReportWebVitals`... Except the useReportWebVitals hook gets called in a context that saves the resulting metrics information to a ref, which the Faro Component polls every second for metrics data.

The reason why this is so complicated is because useReportWebVitals is typically used for 1-and-done metrics telemetry (I.E. oh we got FID? posthog that jawn and forget about it). On every page refresh, the useReportWebVitals hook reinitializes and sets another listener for metrics, (it does this for every page refresh) causing an infinite loop of reinitializing. Because of this I had to slap it in a context at the very top level of the site and have it feed the data to a useRef variable (passed to a webVitalsContext that wraps the whole site) that gets polled by whatever component needs that data.

Now I get to see all my performance issues in 8k Ultra HD glory 🤤

Some extra things this PR does
- Fixes the missing alt properties on a bunch of Images across the site
- Also fixes the spotify component having an invalid key when I'm not listening to anything

## Notes
They not like us 😱 They not like us 😱 They not like us 😱 They not like us 😱 They not like us 😱 They not like us 😱