### PR TITLE
[Enhancement] - Get most recent fully played track instead of what is currently playing on my spotify

### DIFF
--- a/src/app/api/get-curr-playing/route.js
+++ b/src/app/api/get-curr-playing/route.js
@@ -9,29 +9,38 @@ const refreshToken = process.env.REFRESH_TOKEN;
 // Grab that access token
 const TOKEN_URL = `https://accounts.spotify.com/api/token`;
 const basicAuth = Buffer.from(`${clientID}:${clientSecret}`).toString('base64');
-const NOW_PLAYING_URL =
-   'https://api.spotify.com/v1/me/player/currently-playing';
+const NOW_PLAYING_URL = 'https://api.spotify.com/v1/me/player/recently-played';
 
-export const dynamic = 'force-dynamic'
+export const dynamic = 'force-dynamic';
 
 export const GET = async () => {
    const { access_token } = await getAccessToken();
-   const info = await fetch(NOW_PLAYING_URL, {
-      next: {
-         revalidate: 0
-      },
-      cache: 'no-store',
-      headers: {
-         Authorization: `Bearer ${access_token}`,
-      },
-   });
-   if (info.status == 204)
+   try {
+      const info = await fetch(NOW_PLAYING_URL, {
+         next: {
+            revalidate: 0,
+         },
+         cache: 'no-store',
+         headers: {
+            Authorization: `Bearer ${access_token}`,
+         },
+      });
+
+      if (info.status == 204)
+         return Response.json(
+            { message: 'Nothing currently playing!' },
+            { status: 200 }
+         );
+
+      const json = await info.json();
+
+      return Response.json({ item: json.items[0].track }, { status: 200 });
+   } catch (err) {
       return Response.json(
          { message: 'Nothing currently playing!' },
-         { status: 200 }
+         { status: 500 }
       );
-   const json = await info.json();
-   return Response.json(json);
+   }
 };
 
 // Gets the access token required for the api call in the handler function


### PR DESCRIPTION
## What this PR does / Why it is needed
Almost 80% I'm not listening to something on spotify, which makes it so that `/me/player/currently-playing/` comes back with no information most of the time. Instead, fetch the last played track and display it on the home page.

## Notes
![image](https://media1.tenor.com/m/GFye_UPGD_sAAAAd/%E3%81%A1%E3%81%84%E3%81%8B%E3%82%8F-chiikawa.gif)