### PR TITLE
fix: disable Next.js fetch caching for last starred repo

### DIFF
--- a/src/app/api/get-last-starred-repo/route.js
+++ b/src/app/api/get-last-starred-repo/route.js
@@ -1,6 +1,7 @@
 import { getLastStarredRepo } from '@/app/api';
 
 export const dynamic = 'force-dynamic'
+export const fetchCache = 'force-no-store'
 
 export const GET = async () => {
    let lastStarredRepo = await getLastStarredRepo();

--- a/src/components/Home/LastStarredRepo.js
+++ b/src/components/Home/LastStarredRepo.js
@@ -23,7 +23,7 @@ const LastStarredRepo = () => {
       return str.split(' ', 14).join(' ') + '...';
    };
    useEffect(() => {
-      fetch('/api/get-last-starred-repo', { next: 'no-store' })
+      fetch('/api/get-last-starred-repo', { cache: 'no-store' })
          .then((response) => {
             return response.json();
          })


### PR DESCRIPTION
## Summary
Github octokit gets declared at module level, and for some reason api calls to github get cached when a given route is hit. By setting fetchCache to force-no-store globally we get past this. I'm only doing this for this particular route since I think I'm good with using cached data for stuff like the /projects page

- Add `fetchCache = 'force-no-store'` to the starred repo API route so octokit's internal fetch bypasses Next.js data cache
- Fix client-side fetch option from `{ next: 'no-store' }` to `{ cache: 'no-store' }`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated data fetching to ensure the last starred repository information is always current.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->