### PR TITLE
feat: audio preview playback with dynamic Deezer URL resolution

### DIFF
--- a/scripts/backfill-deezer-ids.mjs
+++ b/scripts/backfill-deezer-ids.mjs
@@ -1,0 +1,171 @@
+/**
+ * Runbook: Backfill deezer_id for existing song_of_the_day rows
+ *
+ * Prerequisites:
+ *   Run this SQL in the Supabase SQL Editor first:
+ *     ALTER TABLE song_of_the_day ADD COLUMN deezer_id bigint;
+ *
+ * This script:
+ *   1. Verifies the `deezer_id` column exists (exits with instructions if not)
+ *   2. Fetches all rows that don't have a `deezer_id` yet
+ *   3. Searches Deezer by title + artist for each, and writes the Deezer track ID back
+ *
+ * Environment variables (reads .env.local automatically):
+ *   NEXT_PUBLIC_SUPABASE_URL
+ *   SUPABASE_SERVICE_ROLE_KEY
+ *
+ * Usage:
+ *   node scripts/backfill-deezer-ids.mjs              # backfill all rows missing deezer_id
+ *   node scripts/backfill-deezer-ids.mjs --dry-run    # preview what would be updated without writing
+ */
+
+import { createClient } from '@supabase/supabase-js';
+
+// ── Load .env.local if present ──────────────────────────────────────────────
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+try {
+   const envPath = resolve(process.cwd(), '.env.local');
+   const envFile = readFileSync(envPath, 'utf-8');
+   for (const line of envFile.split('\n')) {
+      const trimmed = line.trim();
+      if (!trimmed || trimmed.startsWith('#')) continue;
+      const eqIdx = trimmed.indexOf('=');
+      if (eqIdx === -1) continue;
+      const key = trimmed.slice(0, eqIdx).trim();
+      const val = trimmed.slice(eqIdx + 1).trim();
+      if (!process.env[key]) process.env[key] = val;
+   }
+} catch {
+   // no .env.local, rely on env vars being set
+}
+
+// ── Config ──────────────────────────────────────────────────────────────────
+const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const SUPABASE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
+const DEEZER_SEARCH_URL = 'https://api.deezer.com/search';
+const DEEZER_DELAY_MS = 300; // rate-limit courtesy delay between requests
+const DRY_RUN = process.argv.includes('--dry-run');
+
+if (!SUPABASE_URL || !SUPABASE_KEY) {
+   console.error(
+      'Missing NEXT_PUBLIC_SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY'
+   );
+   process.exit(1);
+}
+
+const supabase = createClient(SUPABASE_URL, SUPABASE_KEY);
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+async function searchDeezerId(title, artist) {
+   const term = `artist:"${artist}" track:"${title}"`;
+   const url = `${DEEZER_SEARCH_URL}?q=${encodeURIComponent(term)}&limit=5`;
+
+   const res = await fetch(url);
+   if (!res.ok) return null;
+
+   const json = await res.json();
+   const tracks = json.data || [];
+   if (tracks.length === 0) return null;
+
+   // Prefer exact title match (case-insensitive), otherwise take first result
+   const titleLower = title.toLowerCase();
+   const exact = tracks.find((t) => t.title?.toLowerCase() === titleLower);
+   const best = exact || tracks[0];
+
+   return best.id || null;
+}
+
+// ── Schema check ────────────────────────────────────────────────────────────
+async function ensureDeezerIdColumn() {
+   const { error } = await supabase
+      .from('song_of_the_day')
+      .select('deezer_id')
+      .limit(1);
+
+   if (error && error.message.includes('deezer_id')) {
+      console.error(
+         'The deezer_id column does not exist yet.\n' +
+         'Run this SQL in the Supabase SQL Editor first:\n\n' +
+         '  ALTER TABLE song_of_the_day ADD COLUMN deezer_id bigint;\n'
+      );
+      process.exit(1);
+   }
+
+   console.log('Schema OK: deezer_id column exists.\n');
+}
+
+// ── Main ────────────────────────────────────────────────────────────────────
+async function main() {
+   console.log(DRY_RUN ? '=== DRY RUN ===' : '=== Backfilling Deezer IDs ===');
+
+   await ensureDeezerIdColumn();
+
+   // Fetch all rows that don't have a deezer_id yet
+   const { data: songs, error } = await supabase
+      .from('song_of_the_day')
+      .select('date, title, artist, deezer_id')
+      .is('deezer_id', null)
+      .order('date', { ascending: true });
+
+   if (error) {
+      console.error('Failed to fetch songs:', error.message);
+      process.exit(1);
+   }
+
+   console.log(`Found ${songs.length} songs missing deezer_id\n`);
+
+   let updated = 0;
+   let skipped = 0;
+   let failed = 0;
+
+   for (const song of songs) {
+      const label = `${song.date} | ${song.artist} - ${song.title}`;
+
+      let deezerId;
+      try {
+         deezerId = await searchDeezerId(song.title, song.artist);
+      } catch (err) {
+         console.log(`  FAIL  ${label} (${err.message})`);
+         failed++;
+         await sleep(DEEZER_DELAY_MS);
+         continue;
+      }
+
+      if (!deezerId) {
+         console.log(`  SKIP  ${label} (no match found on Deezer)`);
+         skipped++;
+         await sleep(DEEZER_DELAY_MS);
+         continue;
+      }
+
+      if (DRY_RUN) {
+         console.log(`  WOULD UPDATE  ${label} → deezer_id=${deezerId}`);
+         updated++;
+      } else {
+         const { error: updateErr } = await supabase
+            .from('song_of_the_day')
+            .update({ deezer_id: deezerId })
+            .eq('date', song.date);
+
+         if (updateErr) {
+            console.log(`  FAIL  ${label} (${updateErr.message})`);
+            failed++;
+         } else {
+            console.log(`  OK    ${label} → deezer_id=${deezerId}`);
+            updated++;
+         }
+      }
+
+      await sleep(DEEZER_DELAY_MS);
+   }
+
+   console.log(
+      `\nDone. ${updated} updated, ${skipped} skipped, ${failed} failed.`
+   );
+}
+
+main();

--- a/src/app/api/admin/music/route.js
+++ b/src/app/api/admin/music/route.js
@@ -48,7 +48,7 @@ export async function GET(request) {
 
 export async function POST(request) {
    const body = await request.json();
-   const { date, title, artist, album, artwork_url, track_url, preview_url } = body;
+   const { date, title, artist, album, artwork_url, track_url, preview_url, id } = body;
 
    if (!date || !title || !artist) {
       return NextResponse.json(
@@ -81,7 +81,7 @@ export async function POST(request) {
    const { data, error } = await supabase
       .from('song_of_the_day')
       .upsert(
-         { date, title, artist, album, artwork_url, track_url, preview_url },
+         { date, title, artist, album, artwork_url, track_url, preview_url, deezer_id: id || null },
          { onConflict: 'date' }
       )
       .select()

--- a/src/app/api/get-song-of-the-day/route.js
+++ b/src/app/api/get-song-of-the-day/route.js
@@ -22,7 +22,7 @@ export const GET = async () => {
 
    const { data, error } = await supabase
       .from('song_of_the_day')
-      .select('date,title,artist,album,artwork_url,track_url,preview_url')
+      .select('date,title,artist,album,artwork_url,track_url,preview_url,deezer_id')
       .order('date', { ascending: false })
       .limit(1);
 
@@ -43,5 +43,6 @@ export const GET = async () => {
       artwork_url: song.artwork_url,
       track_url: song.track_url,
       preview_url: song.preview_url || null,
+      deezer_id: song.deezer_id || null,
    });
 };

--- a/src/app/api/music/preview/route.js
+++ b/src/app/api/music/preview/route.js
@@ -1,0 +1,59 @@
+import { NextResponse } from 'next/server';
+
+export const dynamic = 'force-dynamic';
+
+const DEEZER_TRACK_URL = 'https://api.deezer.com/track';
+const FETCH_TIMEOUT = 6000;
+const MAX_IDS = 50;
+
+async function fetchPreviewUrl(id) {
+   const controller = new AbortController();
+   const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT);
+   try {
+      const res = await fetch(`${DEEZER_TRACK_URL}/${id}`, {
+         signal: controller.signal,
+      });
+      if (!res.ok) return null;
+      const json = await res.json();
+      return json.preview || null;
+   } catch {
+      return null;
+   } finally {
+      clearTimeout(timer);
+   }
+}
+
+export async function GET(request) {
+   const { searchParams } = new URL(request.url);
+   const idsParam = searchParams.get('ids');
+
+   if (!idsParam) {
+      return NextResponse.json(
+         { error: 'ids param required' },
+         { status: 400 }
+      );
+   }
+
+   const ids = idsParam
+      .split(',')
+      .map((s) => s.trim())
+      .filter(Boolean)
+      .slice(0, MAX_IDS);
+
+   if (ids.length === 0) {
+      return NextResponse.json({ previews: {} });
+   }
+
+   const results = await Promise.allSettled(
+      ids.map(async (id) => ({ id, url: await fetchPreviewUrl(id) }))
+   );
+
+   const previews = {};
+   for (const result of results) {
+      if (result.status === 'fulfilled') {
+         previews[result.value.id] = result.value.url;
+      }
+   }
+
+   return NextResponse.json({ previews });
+}

--- a/src/components/Admin/MusicCalendar.jsx
+++ b/src/components/Admin/MusicCalendar.jsx
@@ -18,6 +18,30 @@ const MusicCalendar = ({ editable = true }) => {
    const fetchIdRef = useRef(0);
    const { preload, clearCache, toggle, playing, playingId } = useAudioPreview();
 
+   const resolvePreviewUrls = useCallback(async (songMap, id) => {
+      const toResolve = Object.values(songMap).filter((s) => s.deezer_id);
+      if (toResolve.length === 0) return;
+      try {
+         const ids = toResolve.map((s) => s.deezer_id).join(',');
+         const res = await fetch(`/api/music/preview?ids=${ids}`);
+         const json = await res.json();
+         if (id !== fetchIdRef.current) return;
+         setSongs((prev) => {
+            const next = { ...prev };
+            for (const s of toResolve) {
+               const url = json.previews?.[s.deezer_id];
+               if (url && next[s.date]) {
+                  next[s.date] = { ...next[s.date], preview_url: url };
+                  preload(url);
+               }
+            }
+            return next;
+         });
+      } catch {
+         // silent — play buttons just won't appear for unresolved songs
+      }
+   }, [preload]);
+
    const fetchSongs = useCallback(async (monthDate) => {
       const id = ++fetchIdRef.current;
       clearCache();
@@ -30,13 +54,16 @@ const MusicCalendar = ({ editable = true }) => {
          const map = {};
          (json.songs || []).forEach((s) => {
             map[s.date] = s;
-            if (s.preview_url) preload(s.preview_url);
+            // Legacy fallback: preload stored preview_url if no deezer_id
+            if (!s.deezer_id && s.preview_url) preload(s.preview_url);
          });
          setSongs(map);
+         // Resolve fresh preview URLs for songs with deezer_id
+         resolvePreviewUrls(map, id);
       } finally {
          if (id === fetchIdRef.current) setLoading(false);
       }
-   }, []);
+   }, [resolvePreviewUrls, clearCache, preload]);
 
    useEffect(() => {
       fetchSongs(currentMonth);
@@ -71,9 +98,26 @@ const MusicCalendar = ({ editable = true }) => {
    for (let i = 0; i < firstDayOfWeek; i++) cells.push(null);
    for (let d = 1; d <= daysInMonth; d++) cells.push(d);
 
-   const handleSave = (savedSong) => {
+   const handleSave = async (savedSong) => {
       setSongs((prev) => ({ ...prev, [savedSong.date]: savedSong }));
       setSelectedDate(null);
+      // Resolve preview URL for the newly saved song
+      if (savedSong.deezer_id) {
+         try {
+            const res = await fetch(`/api/music/preview?ids=${savedSong.deezer_id}`);
+            const json = await res.json();
+            const url = json.previews?.[savedSong.deezer_id];
+            if (url) {
+               setSongs((prev) => ({
+                  ...prev,
+                  [savedSong.date]: { ...prev[savedSong.date], preview_url: url },
+               }));
+               preload(url);
+            }
+         } catch {
+            // silent
+         }
+      }
    };
 
    return (

--- a/src/components/Home/SongOfTheDayComponent.js
+++ b/src/components/Home/SongOfTheDayComponent.js
@@ -38,10 +38,25 @@ const SongOfTheDayComponent = () => {
    useEffect(() => {
       fetch('/api/get-song-of-the-day', { cache: 'no-store' })
          .then((r) => r.json())
-         .then((json) => {
-            if (json.date) {
-               setSong(json);
-               if (json.preview_url) preload(json.preview_url);
+         .then(async (json) => {
+            if (!json.date) return;
+            setSong(json);
+            // Resolve preview URL dynamically if deezer_id is present
+            if (json.deezer_id) {
+               try {
+                  const res = await fetch(`/api/music/preview?ids=${json.deezer_id}`);
+                  const data = await res.json();
+                  const url = data.previews?.[json.deezer_id];
+                  if (url) {
+                     setSong((prev) => ({ ...prev, preview_url: url }));
+                     preload(url);
+                  }
+               } catch {
+                  // silent — play button won't appear
+               }
+            } else if (json.preview_url) {
+               // Legacy fallback for songs without deezer_id
+               preload(json.preview_url);
             }
          })
          .catch((err) => console.error('SongOfTheDay fetch failed', err))

--- a/src/components/hooks/useAudioPreview.js
+++ b/src/components/hooks/useAudioPreview.js
@@ -66,7 +66,10 @@ const useAudioPreview = () => {
 
    const cleanupEnded = () => {
       if (endedHandlerRef.current && activeRef.current) {
-         activeRef.current.removeEventListener('ended', endedHandlerRef.current);
+         activeRef.current.removeEventListener(
+            'ended',
+            endedHandlerRef.current
+         );
          endedHandlerRef.current = null;
       }
    };
@@ -152,9 +155,10 @@ const useAudioPreview = () => {
    const toggle = useCallback(
       (previewUrl, id) => {
          // Match by id when provided, otherwise fall back to URL
-         const isActive = id != null
-            ? playing && playingId === id
-            : playing && playingUrl === previewUrl;
+         const isActive =
+            id != null
+               ? playing && playingId === id
+               : playing && playingUrl === previewUrl;
          if (isActive) {
             pause();
          } else {
@@ -164,7 +168,16 @@ const useAudioPreview = () => {
       [playing, playingId, playingUrl, play, pause]
    );
 
-   return { preload, clearCache, play, pause, toggle, playing, playingUrl, playingId };
+   return {
+      preload,
+      clearCache,
+      play,
+      pause,
+      toggle,
+      playing,
+      playingUrl,
+      playingId,
+   };
 };
 
 export default useAudioPreview;


### PR DESCRIPTION
## Summary

- **Audio preview playback** for the song-of-the-day calendar (admin) and the public homepage widget — 30-second Deezer previews with fade-in/fade-out
- **Dynamic preview URL resolution** — stores the stable Deezer track ID (`deezer_id`) instead of ephemeral CDN preview URLs that expire daily, resolving fresh URLs at runtime via a new batch proxy endpoint (`/api/music/preview`)
- **Backfill script** (`scripts/backfill-deezer-ids.mjs`) to populate `deezer_id` for existing songs in Supabase
- Legacy fallback: songs without a `deezer_id` still use their stored `preview_url` during the transition period

## Migration steps (post-merge)

1. Run SQL: `ALTER TABLE song_of_the_day ADD COLUMN deezer_id bigint;`
2. Run backfill: `node scripts/backfill-deezer-ids.mjs --dry-run`, then without the flag
3. After validation, `preview_url` column can be dropped in a follow-up

## Test plan

- [ ] Verify new songs saved via admin calendar persist `deezer_id` in Supabase
- [ ] Verify admin calendar play buttons appear after brief background resolution
- [ ] Verify public homepage song-of-the-day widget plays audio
- [ ] Verify backfill script correctly populates `deezer_id` for existing rows
- [ ] Verify songs without `deezer_id` still fall back to stored `preview_url`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Integrated Deezer music preview functionality, enabling users to preview songs across the application.

* **Chores**
  * Added data backfill utility for historical music records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->