### PR TITLE
Improvement - public song of the day calendar

### DIFF
--- a/src/app/api/music/route.js
+++ b/src/app/api/music/route.js
@@ -1,0 +1,46 @@
+import { createClient } from '@supabase/supabase-js';
+import { NextResponse } from 'next/server';
+
+const supabase = createClient(
+   process.env.NEXT_PUBLIC_SUPABASE_URL,
+   process.env.SUPABASE_SERVICE_ROLE_KEY
+);
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(request) {
+   const { searchParams } = new URL(request.url);
+   const month = searchParams.get('month'); // YYYY-MM
+
+   if (!month) {
+      return NextResponse.json(
+         { error: 'month param required' },
+         { status: 400 }
+      );
+   }
+
+   const [year, mon] = month.split('-').map(Number);
+
+   if (!year || !mon || mon < 1 || mon > 12) {
+      return NextResponse.json(
+         { error: 'Invalid month value' },
+         { status: 400 }
+      );
+   }
+
+   const start = `${month}-01`;
+   const endDate = new Date(year, mon, 0);
+   const end = `${month}-${String(endDate.getDate()).padStart(2, '0')}`;
+
+   const { data, error } = await supabase
+      .from('song_of_the_day')
+      .select('*')
+      .gte('date', start)
+      .lte('date', end);
+
+   if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+   }
+
+   return NextResponse.json({ songs: data });
+}

--- a/src/app/music/page.js
+++ b/src/app/music/page.js
@@ -1,0 +1,46 @@
+import Head from 'next/head';
+import React from 'react';
+import Footer from '@/components/Footer/Footer.js';
+import Header from '@/components/Header/Header.js';
+import Navbar from '@/components/NavBar/Navbar';
+import MusicCalendar from '@/components/Admin/MusicCalendar';
+
+export const dynamic = 'force-dynamic';
+
+const MusicPage = () => {
+   return (
+      <>
+         <Head>
+            <title>AngelFolio | Music</title>
+            <meta
+               name='description'
+               content="Angel's Song of the Day calendar"
+            />
+            <meta
+               name='viewport'
+               content='width=device-width, initial-scale=1'
+            />
+            <meta
+               name='image'
+               content='https://www.angel1254.com/link-image.png'
+            />
+            <meta
+               property='og:image'
+               content='https://www.angel1254.com/link-image.png'
+            />
+            <meta name='twitter:card' content='summary_large_image'></meta>
+            <link rel='icon' href='/favicon.ico' />
+         </Head>
+         <main className='w-full flex flex-col items-center'>
+            <div className='w-full max-w-[50rem] 2xl:max-w-[64rem] flex flex-col justify-start py-2 px-6'>
+               <Navbar />
+               <Header title={'Music'} subtitle="I don't make music, this is just what I've been listening to recently." />
+            </div>
+            <MusicCalendar editable={false} />
+            <Footer />
+         </main>
+      </>
+   );
+};
+
+export default MusicPage;

--- a/src/app/resume/page.js
+++ b/src/app/resume/page.js
@@ -62,7 +62,7 @@ const index = ({}) => {
                               Herbert Wertheim College of Engineering
                            </p>
                            <p className='font-light text-sm sm:text-base'>
-                              <b className='text-bold'>GPA:</b> 3.82
+                              <b className='text-bold'>GPA:</b> 3.8/4.0
                            </p>
                         </div>
                      </div>
@@ -100,19 +100,10 @@ const index = ({}) => {
 
                            <ul className='ml-8 list-disc font-extralight sm:text-base text-sm mt-2'>
                               <li>
-                                 Led frontend development of ALTR&apos;s Unified
-                                 Policy project, extending Snowflake Masking
-                                 support to Databricks in close collaboration
-                                 with backend and platform teams.
-                              </li>
-                              <li>
-                                 Developed a novel web-signup flow utilizing AWS
-                                 WAF Captcha challenges. Collaborated with
-                                 members of the product team to track the signup
-                                 journey via Mixpanel events. Standardized
-                                 ALTR&apos;s Figma design system as an
-                                 extensible MaterialUI-based component library
-                                 for use across our various web components
+                                 Owned frontend development of ALTR&apos;s
+                                 Unified Policy project, extending Snowflake
+                                 Masking support to Databricks in close
+                                 collaboration with backend and platform teams.
                               </li>
                               <li>
                                  Standardized ALTR&apos;s Figma design system as
@@ -122,7 +113,7 @@ const index = ({}) => {
                               </li>
                               <li>
                                  Built performant infinite-scroll data tables
-                                 supporting 100k+ columns using memoization and
+                                 supporting 100k+ rows using memoization and
                                  table virtualization for fast filtering. This
                                  enabled frontend functionality to support
                                  ALTR&apos;s Databricks and Snowflake
@@ -134,6 +125,12 @@ const index = ({}) => {
                                  enrich Mixpanel events, giving the Product team
                                  insight into lambda latency patterns and
                                  informing product roadmap decisions.
+                              </li>
+                              <li>
+                                 Developed a novel web-signup flow utilizing AWS
+                                 WAF Captcha challenges. Collaborated with
+                                 members of the product team to track the signup
+                                 journey via Mixpanel events.
                               </li>
                            </ul>
                         </div>
@@ -154,51 +151,52 @@ const index = ({}) => {
                         </div>
                         <div className='flex flex-col gap-x-1'>
                            <h3 className='sm:text-lg text-base font-semibold'>
-                              Software Engineer Intern - Grafana Labs Inc
+                              Software Engineering Intern | Grafana Labs
                            </h3>
                            <p className='block md:hidden sm:text-base text-sm'>
-                              June 2023 - Aug. 2023
+                              June 2023 - August 2023
                            </p>
                            <p className='sm:text-base text-sm font-extralight italic'>
-                              Helped push the new Metrics Endpoint Integration,
-                              from scratch to production.
+                              Pushed the new Metrics Endpoint Integration, from
+                              scratch to production.
                            </p>
 
                            <ul className='ml-8 list-disc font-extralight sm:text-base text-sm mt-2'>
                               <li>
-                                 Helped bring to fruition a SaaS integration
-                                 that began as a Hackathon project.{' '}
+                                 Developed a high-demand SaaS integration that
+                                 started as a hackathon project. Wrote the
+                                 backend in Go, and a custom frontend using
+                                 React.
                               </li>
                               <li>
                                  Leveraged Jsonnet, Tanka, and K8s for
                                  configuring HPAs, DNS rules, and resource
-                                 limits to support the integration across 17
-                                 regions worldwide.
+                                 limits to support the SaaS integration across
+                                 17 regions worldwide.
                               </li>
                               <li>
                                  Independently implemented user-desired
                                  accessibility improvements across the
-                                 connections-console frontend.
+                                 cloud-onboarding frontend.
                               </li>
                               <li>
-                                 Asynchronously collaborated with colleagues
-                                 across multiple teams and timezones, making
-                                 contributions in all layers of development
-                                 (frontend, backend, and platform)
+                                 Collaborated with colleagues across multiple
+                                 teams and made contributions in all layers of
+                                 application development (backend, frontend, and
+                                 platform).
                               </li>
                               <li>
                                  Participated in a company-wide hackathon,
                                  developed a new cloud integration for importing
                                  NextJS Traces, Spans, and Metrics to Grafana
-                                 Cloud. Now owned by the OTEL team who is
-                                 pushing it to production.
+                                 Cloud.
                               </li>
                            </ul>
                         </div>
                      </div>
                      <div className='flex flex-col text-base font-semibold mt-4'>
                         <p className='text-right md:block hidden'>
-                           June 2023 - Aug. 2023
+                           June 2023 - August 2023
                         </p>
                      </div>
                   </div>
@@ -212,49 +210,47 @@ const index = ({}) => {
                         </div>
                         <div className='flex flex-col gap-x-1'>
                            <h3 className='sm:text-lg text-base font-semibold'>
-                              Associate Software Engineer - Emerging Tech LLC
+                              Fullstack Engineering Intern | Emerging Tech LLC
                            </h3>
                            <p className='block md:hidden sm:text-base text-sm'>
-                              May 2022 - May 2023
+                              May 2022 - June 2023, Sept 2023 - May 2024
                            </p>
                            <p className='sm:text-base text-sm font-extralight italic'>
-                              Provided Web Development expertise and led
-                              development of internal CRM systems.
+                              Provided Web Dev support and led development of
+                              internal CRM systems.
                            </p>
 
                            <ul className='ml-8 list-disc font-extralight text-sm sm:text-base mt-2'>
                               <li>
-                                 Leading development of an internal Gov.
-                                 Contracting Management System for real-time
-                                 proposal discovery, procurement, and
-                                 management.
+                                 Led architecture and development of internal
+                                 Gov Contracting System with Next.js, Flask, and
+                                 Firebase.
                               </li>
                               <li>
-                                 Created a scalable contract search microservice
-                                 that autonomously discovers over 100 actionable
-                                 government contracts every day and persists
-                                 concurrent information on over 11,000
-                                 government opportunities across several NAICS
-                                 codes.
+                                 Built microservice that discovers 100+ new
+                                 government contracts daily and indexes 11,000+
+                                 opportunities by NAICS code.
                               </li>
                               <li>
                                  Refactored and redesigned WordPress company
-                                 website. Increased Google Lighthouse Score to
-                                 90 across all key measurements.
+                                 website. Implemented optimized caching
+                                 strategies to reduce load times and increase
+                                 Google Lighthouse Score to 90 across all key
+                                 measurements.
                               </li>
                               <li>
                                  Worked as a consultant developing a website for
                                  another company, Gen Z Consulting LLC.
-                                 Delivered according to stakeholder’s needs and
-                                 requirements and achieved &gt;= 85 Google
-                                 Lighthouse score across all key measurements
+                                 Delivered according to stakeholder&apos;s needs
+                                 and requirements and achieved 100 Google
+                                 Lighthouse scores across all key measurements.
                               </li>
                            </ul>
                         </div>
                      </div>
                      <div className='flex flex-col text-base font-semibold mt-4'>
                         <p className='text-right md:block hidden'>
-                           May 2022 - May 2023
+                           May 2022 - June 2023, Sept 2023 - May 2024
                         </p>
                      </div>
                   </div>

--- a/src/components/Admin/CalendarCell.jsx
+++ b/src/components/Admin/CalendarCell.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { PlayIcon, PauseIcon, EditIcon } from '../icons/AudioIcons';
+import { PlayIcon, PauseIcon, EditIcon, LinkIcon } from '../icons/AudioIcons';
 
 const handleImageLoad = (e) => {
    e.currentTarget.classList.remove('opacity-0', 'scale-95');
@@ -34,9 +34,9 @@ const CalendarCell = ({
       aria-label={`${dateStr}${song ? ` — ${song.title} by ${song.artist}` : ''}`}
       className={`aspect-square relative rounded-md overflow-hidden border transition-all group
          ${isToday ? 'border-purple-500' : 'border-[#242424]'}
-         ${song ? '' : 'bg-[#101010] hover:bg-[#1a1a1a] cursor-pointer'}
+         ${song ? '' : `bg-[#101010] ${editable ? 'hover:bg-[#1a1a1a] cursor-pointer' : ''}`}
       `}
-      onClick={!song ? () => onEdit(dateStr) : undefined}
+      onClick={!song && editable ? () => onEdit(dateStr) : undefined}
    >
       {song ? (
          <>
@@ -80,13 +80,25 @@ const CalendarCell = ({
                      <EditIcon />
                   </button>
                )}
+               {!editable && song.track_url && (
+                  <a
+                     href={song.track_url}
+                     target='_blank'
+                     rel='noreferrer'
+                     onClick={(e) => e.stopPropagation()}
+                     className='w-8 h-8 rounded-full bg-white/20 hover:bg-white/30 flex items-center justify-center text-white transition-colors'
+                     aria-label='Open on Deezer'
+                  >
+                     <LinkIcon />
+                  </a>
+               )}
             </div>
          </>
-      ) : (
+      ) : editable ? (
          <span className='absolute inset-0 flex items-center justify-center text-gray-600 group-hover:text-gray-400 text-sm font-medium transition-colors'>
             +
          </span>
-      )}
+      ) : null}
       <span
          className={`absolute top-1 left-1 text-xs font-bold leading-none
             ${song ? 'text-white drop-shadow' : isToday ? 'text-purple-400' : 'text-gray-500'}

--- a/src/components/Admin/MusicCalendar.jsx
+++ b/src/components/Admin/MusicCalendar.jsx
@@ -48,7 +48,8 @@ const MusicCalendar = ({ editable = true }) => {
       setLoading(true);
       try {
          const month = toYYYYMM(monthDate);
-         const res = await fetch(`/api/admin/music?month=${month}`);
+         const apiBase = editable ? '/api/admin/music' : '/api/music';
+         const res = await fetch(`${apiBase}?month=${month}`);
          const json = await res.json();
          if (id !== fetchIdRef.current) return;
          const map = {};
@@ -63,7 +64,7 @@ const MusicCalendar = ({ editable = true }) => {
       } finally {
          if (id === fetchIdRef.current) setLoading(false);
       }
-   }, [resolvePreviewUrls, clearCache, preload]);
+   }, [editable, resolvePreviewUrls, clearCache, preload]);
 
    useEffect(() => {
       fetchSongs(currentMonth);
@@ -194,7 +195,7 @@ const MusicCalendar = ({ editable = true }) => {
             />
          )}
 
-         {selectedDate && (
+         {editable && selectedDate && (
             <MusicSearchModal
                date={selectedDate}
                existingSong={songs[selectedDate] || null}

--- a/src/components/Admin/SongTooltip.jsx
+++ b/src/components/Admin/SongTooltip.jsx
@@ -17,6 +17,9 @@ const SongTooltip = ({ song, x, y }) => (
          <div className='flex-1 min-w-0'>
             <p className='text-sm font-medium truncate'>{song.title}</p>
             <p className='text-xs text-gray-400 truncate'>{song.artist}</p>
+            {song.album && (
+               <p className='text-xs text-gray-500 truncate'>{song.album}</p>
+            )}
          </div>
       </div>
    </div>

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -16,7 +16,7 @@ const random = (min, max) => {
  * @param {*} param0
  * @returns
  */
-function Header({ title, size = null, animateStyle = {}, interval = 3000 }) {
+function Header({ title, subtitle, size = null, animateStyle = {}, interval = 3000 }) {
    if (title.length > 25) size = '3rem';
    const ref = useRef();
    useEffect(() => {
@@ -31,9 +31,14 @@ function Header({ title, size = null, animateStyle = {}, interval = 3000 }) {
    }, []);
 
    return (
-      <animated.div ref={ref} style={animateStyle} className={styles.gradient}>
-         {title}
-      </animated.div>
+      <div>
+         <animated.div ref={ref} style={{ ...animateStyle, ...(subtitle ? { marginBottom: 0 } : {}) }} className={styles.gradient}>
+            {title}
+         </animated.div>
+         {subtitle && (
+            <p className='text-sm text-gray-400 mt-3 mb-5 font-light'>{subtitle}</p>
+         )}
+      </div>
    );
 }
 

--- a/src/components/Home/IntroComponent.js
+++ b/src/components/Home/IntroComponent.js
@@ -24,7 +24,7 @@ const IntroComponent = () => {
       config: { mass: 5, tension: 500, friction: 80 },
    });
 
-   const firstParagraph = `I'm Angel, a <Sheen>Junior Frontend Engineer</Sheen> at <Sheen>ALTR</Sheen> who recently graduated from <Sheen>UF</Sheen> this past May! I'm a passionate, results-driven software and web developer. My past work experience mainly consists of <Sheen>Web Dev</Sheen>, <Sheen>Systems Engineering</Sheen>, and <Sheen>UI Design.</Sheen>`;
+   const firstParagraph = `I'm Angel, a <Sheen>Frontend Engineer II</Sheen> at <Sheen>ALTR</Sheen> and a <Sheen>UF</Sheen> grad (Class of 2024). I'm a passionate, results-driven software and web developer. My past work experience mainly consists of <Sheen>Web Dev</Sheen>, <Sheen>Systems Engineering</Sheen>, and <Sheen>UI Design.</Sheen>`;
    const secondParagraph = `I love browsing <Sheen>GitHub</Sheen> in search of new <Sheen>open-source technologies</Sheen> to try out and learn. Lately I've been learning a lot about the AWS suite of tools and IaC tech like Terraform.`;
    const thirdParagraph = `I like to post about pretty much anything on my <Sheen>Blog</Sheen> every-so-often. In my free time I like to watch <Sheen>YouTube</Sheen>, play <Sheen>Video Games</Sheen>, and play <Sheen> Racquetball</Sheen>.`;
 

--- a/src/components/NavBar/Navbar.js
+++ b/src/components/NavBar/Navbar.js
@@ -18,6 +18,9 @@ function Navbar() {
          >
             Projects
          </div>
+         <div className={styles.navlink} onClick={() => router.push('/music')}>
+            Music
+         </div>
          <div className={styles.navlink} onClick={() => router.push('/resume')}>
             Resume
          </div>

--- a/src/components/icons/AudioIcons.jsx
+++ b/src/components/icons/AudioIcons.jsx
@@ -12,6 +12,22 @@ export const PauseIcon = ({ className = 'w-4 h-4' }) => (
    </svg>
 );
 
+export const LinkIcon = ({ className = 'w-4 h-4' }) => (
+   <svg
+      className={className}
+      fill='none'
+      viewBox='0 0 24 24'
+      stroke='currentColor'
+      strokeWidth={2}
+   >
+      <path
+         strokeLinecap='round'
+         strokeLinejoin='round'
+         d='M13.5 6H5.25A2.25 2.25 0 0 0 3 8.25v10.5A2.25 2.25 0 0 0 5.25 21h10.5A2.25 2.25 0 0 0 18 18.75V10.5m-10.5 6L21 3m0 0h-5.25M21 3v5.25'
+      />
+   </svg>
+);
+
 export const EditIcon = ({ className = 'w-4 h-4' }) => (
    <svg
       className={className}


### PR DESCRIPTION
## What this PR does / Why it is needed
Currently the calendar with the song of the day only lives on the admin page, but what if it could live on a public page so all my historical songs of the day show up? That would be huge. The time has come.

## Notes
https://github.com/user-attachments/assets/bf5d0003-f2a9-4833-8380-1b56343c7953



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Music section with month-based song filtering and calendar view
  * Added album information display in song tooltips
  * Added external track links for playable songs
  * Added Music navigation menu item

* **Updates**
  * Updated resume content and professional experience descriptions
  * Updated professional introduction text
  * Enhanced Header component with subtitle support

<!-- end of auto-generated comment: release notes by coderabbit.ai -->