### PR TITLE
fix: consistent page widths across Blog and Projects

### DIFF
--- a/src/app/blog/page.js
+++ b/src/app/blog/page.js
@@ -12,7 +12,7 @@ const index = async () => {
    return (
       <>
          <HeadersCustom title={'Posts by Tag'} />
-         <main className='flex flex-col pt-2 px-6 max-w-[50rem] align-center m-auto min-h-[600px] w-full'>
+         <main className='flex flex-col pt-2 px-6 max-w-[50rem] 2xl:max-w-[64rem] align-center m-auto min-h-[600px] w-full'>
             <Navbar />
             <Header title={'Blog'} />
             <BlogList posts={posts} />

--- a/src/app/projects/page.js
+++ b/src/app/projects/page.js
@@ -29,7 +29,7 @@ const ProjectsIndex = async ({}) => {
          />
          <main
             className={
-               'flex flex-col pt-2 px-6 max-w-[50rem] align-center m-auto min-h-[600px] w-full'
+               'flex flex-col pt-2 px-6 max-w-[50rem] 2xl:max-w-[64rem] align-center m-auto min-h-[600px] w-full'
             }
          >
             <Navbar />


### PR DESCRIPTION
## Summary
- Blog and Projects pages were missing the `2xl:max-w-[64rem]` responsive breakpoint that Home, Music, and Resume pages have
- This caused a 224px width difference on 2xl+ screens, resulting in a visible header jolt when navigating between pages
- Added the missing breakpoint to both pages for consistent layout

## Test plan
- [ ] Navigate between all pages (Home, Blog, Projects, Music, Resume) on a 2xl+ screen and verify no layout shift
- [ ] Verify pages still look correct at smaller breakpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated responsive layout widths for blog and projects pages to better accommodate larger displays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->