### PR TITLE
fix: prevent stale cached responses from /api/music

### DIFF
--- a/src/app/api/music/route.js
+++ b/src/app/api/music/route.js
@@ -1,14 +1,21 @@
 import { createClient } from '@supabase/supabase-js';
 import { NextResponse } from 'next/server';
 
-const supabase = createClient(
-   process.env.NEXT_PUBLIC_SUPABASE_URL,
-   process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
-);
-
 export const dynamic = 'force-dynamic';
 
 export async function GET(request) {
+   // Client initialized per-request with cache: 'no-store' to prevent Next.js
+   // module-level caching from serving stale Supabase responses.
+   const supabase = createClient(
+      process.env.NEXT_PUBLIC_SUPABASE_URL,
+      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
+      {
+         global: {
+            fetch: (url, options = {}) =>
+               fetch(url, { ...options, cache: 'no-store' }),
+         },
+      }
+   );
    const { searchParams } = new URL(request.url);
    const month = searchParams.get('month'); // YYYY-MM
 


### PR DESCRIPTION
## Summary
- Moves Supabase client creation from module level into the request handler with `cache: 'no-store'`
- Fixes stale song-of-the-day calendar data on the `/music` page
- Matches the per-request client pattern already used in `/api/get-song-of-the-day`

## Test plan
- [ ] Visit `/music` and confirm the calendar shows songs up to today's date
- [ ] Add a new song of the day via admin and verify it appears on `/music` without redeployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the music API to ensure responses are always fresh and current, preventing stale data from being served to users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->