### PR TITLE
feat: YouTube snippet song-of-the-day (pick, clear, zoomed picker)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,8 @@ yarn-error.log*
 .superpowers/
 .claude/skills/impeccable/*
 /claude/.worktrees
+
+# Internal superpowers process docs — kept local, never pushed
+docs/superpowers/plans/
+docs/superpowers/specs/
+docs/superpowers/handoffs/

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,8 @@ yarn-error.log*
 
 # claude code
 .claude/settings.local.json
+
+# Superpowers brainstorming companion
+.superpowers/
+.claude/skills/impeccable/*
+/claude/.worktrees

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,7 @@ NEXT_PUBLIC_FARO_URL                         # Grafana Faro collector URL
 LOKI_URL / LOKI_INSTANCE_ID / LOKI_AUTH_TOKEN # Grafana Loki logging
 ANGEL_ADMIN_EMAIL                            # Admin login email
 LOG_LEVEL                                    # DEBUG | INFO | WARN | ERROR | FATAL
-MUSIC_DL_URL                                 # Base URL of the music-download-service
+MUSIC_DL_SERVICE_URL                         # Base URL of the music-download-service
 MUSIC_DL_API_KEY                             # Bearer token for the music-download-service (matches its CONVERT_API_KEY)
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,8 @@ NEXT_PUBLIC_FARO_URL                         # Grafana Faro collector URL
 LOKI_URL / LOKI_INSTANCE_ID / LOKI_AUTH_TOKEN # Grafana Loki logging
 ANGEL_ADMIN_EMAIL                            # Admin login email
 LOG_LEVEL                                    # DEBUG | INFO | WARN | ERROR | FATAL
+MUSIC_DL_URL                                 # Base URL of the music-download-service
+MUSIC_DL_API_KEY                             # Bearer token for the music-download-service (matches its CONVERT_API_KEY)
 ```
 
 ## Architecture

--- a/docs/superpowers/migrations/2026-06-14-song-of-the-day-youtube-snippets.sql
+++ b/docs/superpowers/migrations/2026-06-14-song-of-the-day-youtube-snippets.sql
@@ -1,0 +1,6 @@
+-- Add YouTube-snippet support to song_of_the_day (additive, backward-compatible).
+alter table public.song_of_the_day
+  add column if not exists source            text not null default 'deezer',
+  add column if not exists snippet_url        text,
+  add column if not exists youtube_id         text,
+  add column if not exists snippet_start_sec  numeric;

--- a/next.config.js
+++ b/next.config.js
@@ -39,6 +39,18 @@ const nextConfig = {
             port: '',
             pathname: '/**',
          },
+         {
+            protocol: 'https',
+            hostname: 'i.ytimg.com',
+            port: '',
+            pathname: '/**',
+         },
+         {
+            protocol: 'https',
+            hostname: 'img.youtube.com',
+            port: '',
+            pathname: '/**',
+         },
       ],
    },
    reactStrictMode: false,

--- a/src/app/api/admin/music/route.js
+++ b/src/app/api/admin/music/route.js
@@ -48,7 +48,20 @@ export async function GET(request) {
 
 export async function POST(request) {
    const body = await request.json();
-   const { date, title, artist, album, artwork_url, track_url, preview_url, id } = body;
+   const {
+      date,
+      title,
+      artist,
+      album,
+      artwork_url,
+      track_url,
+      preview_url,
+      id,
+      source,
+      snippet_url,
+      youtube_id,
+      snippet_start_sec,
+   } = body;
 
    if (!date || !title || !artist) {
       return NextResponse.json(
@@ -81,7 +94,21 @@ export async function POST(request) {
    const { data, error } = await supabase
       .from('song_of_the_day')
       .upsert(
-         { date, title, artist, album, artwork_url, track_url, preview_url, deezer_id: id || null },
+         {
+            date,
+            title,
+            artist,
+            album,
+            artwork_url,
+            track_url,
+            preview_url,
+            deezer_id: id || null,
+            source: source || 'deezer',
+            snippet_url: snippet_url || null,
+            youtube_id: youtube_id || null,
+            snippet_start_sec:
+               typeof snippet_start_sec === 'number' ? snippet_start_sec : null,
+         },
          { onConflict: 'date' }
       )
       .select()

--- a/src/app/api/admin/music/route.js
+++ b/src/app/api/admin/music/route.js
@@ -155,7 +155,11 @@ export async function DELETE(request) {
       .maybeSingle();
 
    if (fetchErr) {
-      return NextResponse.json({ error: fetchErr.message }, { status: 500 });
+      console.error('[admin/music DELETE] row lookup failed:', fetchErr);
+      return NextResponse.json(
+         { error: 'Internal server error' },
+         { status: 500 }
+      );
    }
 
    // Nothing to clear — idempotent success.
@@ -187,7 +191,11 @@ export async function DELETE(request) {
       .eq('date', date);
 
    if (delErr) {
-      return NextResponse.json({ error: delErr.message }, { status: 500 });
+      console.error('[admin/music DELETE] row delete failed:', delErr);
+      return NextResponse.json(
+         { error: 'Internal server error' },
+         { status: 500 }
+      );
    }
 
    return NextResponse.json(warning ? { ok: true, warning } : { ok: true });

--- a/src/app/api/admin/music/route.js
+++ b/src/app/api/admin/music/route.js
@@ -1,5 +1,6 @@
 import { createClient } from '@supabase/supabase-js';
 import { NextResponse } from 'next/server';
+import { musicDlFetch } from '@/lib/musicDl';
 
 const supabase = createClient(
    process.env.NEXT_PUBLIC_SUPABASE_URL,
@@ -119,4 +120,75 @@ export async function POST(request) {
    }
 
    return NextResponse.json({ song: data });
+}
+
+export async function DELETE(request) {
+   const { searchParams } = new URL(request.url);
+   const date = searchParams.get('date');
+
+   if (!date || !/^\d{4}-\d{2}-\d{2}$/.test(date)) {
+      return NextResponse.json(
+         { error: 'date must be YYYY-MM-DD' },
+         { status: 400 }
+      );
+   }
+
+   // Round-trip validate: ensure the date is a real calendar date
+   const [y, m, d] = date.split('-').map(Number);
+   const probe = new Date(y, m - 1, d);
+   if (
+      probe.getFullYear() !== y ||
+      probe.getMonth() !== m - 1 ||
+      probe.getDate() !== d
+   ) {
+      return NextResponse.json(
+         { error: 'Invalid calendar date' },
+         { status: 400 }
+      );
+   }
+
+   // Look up the row so we know whether a snippet cascade is needed.
+   const { data: existing, error: fetchErr } = await supabase
+      .from('song_of_the_day')
+      .select('source, snippet_url')
+      .eq('date', date)
+      .maybeSingle();
+
+   if (fetchErr) {
+      return NextResponse.json({ error: fetchErr.message }, { status: 500 });
+   }
+
+   // Nothing to clear — idempotent success.
+   if (!existing) {
+      return NextResponse.json({ ok: true });
+   }
+
+   // Best-effort snippet cascade for YouTube days.
+   let warning;
+   if (existing.source === 'youtube' && existing.snippet_url) {
+      try {
+         const res = await musicDlFetch('/yt/snippet', {
+            method: 'DELETE',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ snippet_url: existing.snippet_url }),
+         });
+         if (!res.ok) {
+            const j = await res.json().catch(() => ({}));
+            warning = `Snippet not deleted: ${j.error || res.status}`;
+         }
+      } catch (err) {
+         warning = `Snippet not deleted: ${err.message}`;
+      }
+   }
+
+   const { error: delErr } = await supabase
+      .from('song_of_the_day')
+      .delete()
+      .eq('date', date);
+
+   if (delErr) {
+      return NextResponse.json({ error: delErr.message }, { status: 500 });
+   }
+
+   return NextResponse.json(warning ? { ok: true, warning } : { ok: true });
 }

--- a/src/app/api/admin/music/search/route.js
+++ b/src/app/api/admin/music/search/route.js
@@ -45,10 +45,15 @@ export async function GET(request) {
       return NextResponse.json({ results: [] });
    }
 
-   // Build scoped query
+   // Build query. `scope=all` runs a free-form, unscoped search (used by the
+   // YouTube enrichment picker, where the query mixes artist + title);
+   // otherwise scope to the artist/track fields.
    const offset = Math.max(0, parseInt(searchParams.get('offset') || '0', 10) || 0);
+   const scope = searchParams.get('scope');
    let term;
-   if (q && artist) {
+   if (q && scope === 'all') {
+      term = q;
+   } else if (q && artist) {
       term = `artist:"${artist}" track:"${q}"`;
    } else if (q) {
       term = `track:"${q}"`;

--- a/src/app/api/admin/music/yt/audio/[jobId]/route.js
+++ b/src/app/api/admin/music/yt/audio/[jobId]/route.js
@@ -1,0 +1,34 @@
+import { musicDlFetch } from '@/lib/musicDl';
+
+export const dynamic = 'force-dynamic';
+
+// Streams the in-RAM song from the service to the (already admin-authed) browser.
+// Passes Range through both ways so <audio> scrubbing + Web Audio decoding work.
+export async function GET(request, { params }) {
+   const { jobId } = params;
+   const range = request.headers.get('range');
+
+   let res;
+   try {
+      res = await musicDlFetch(`/yt/audio/${encodeURIComponent(jobId)}`, {
+         headers: range ? { Range: range } : {},
+      });
+   } catch (err) {
+      return new Response(err.message, { status: 500 });
+   }
+
+   const headers = new Headers();
+   for (const h of [
+      'content-type',
+      'content-length',
+      'content-range',
+      'accept-ranges',
+      'cache-control',
+   ]) {
+      const v = res.headers.get(h);
+      if (v) headers.set(h, v);
+   }
+   if (!headers.has('cache-control')) headers.set('cache-control', 'no-store');
+
+   return new Response(res.body, { status: res.status, headers });
+}

--- a/src/app/api/admin/music/yt/audio/[jobId]/route.js
+++ b/src/app/api/admin/music/yt/audio/[jobId]/route.js
@@ -2,8 +2,8 @@ import { musicDlFetch } from '@/lib/musicDl';
 
 export const dynamic = 'force-dynamic';
 
-// Streams the in-RAM song from the service to the (already admin-authed) browser.
-// Passes Range through both ways so <audio> scrubbing + Web Audio decoding work.
+// Streams the song audio from the music-dl-service to the (already admin-authed)
+// browser. Passes Range through both ways so <audio> scrubbing + Web Audio decoding work.
 export async function GET(request, { params }) {
    const { jobId } = params;
    const range = request.headers.get('range');
@@ -18,16 +18,16 @@ export async function GET(request, { params }) {
    }
 
    const headers = new Headers();
-   for (const h of [
+   [
       'content-type',
       'content-length',
       'content-range',
       'accept-ranges',
       'cache-control',
-   ]) {
+   ].forEach((h) => {
       const v = res.headers.get(h);
       if (v) headers.set(h, v);
-   }
+   });
    if (!headers.has('cache-control')) headers.set('cache-control', 'no-store');
 
    return new Response(res.body, { status: res.status, headers });

--- a/src/app/api/admin/music/yt/clip/route.js
+++ b/src/app/api/admin/music/yt/clip/route.js
@@ -4,7 +4,12 @@ import { musicDlFetch } from '@/lib/musicDl';
 export const dynamic = 'force-dynamic';
 
 export async function POST(request) {
-   const body = await request.json().catch(() => ({}));
+   let body;
+   try {
+      body = await request.json();
+   } catch {
+      return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+   }
    const { jobId, startSec } = body;
 
    if (!jobId || typeof startSec !== 'number') {

--- a/src/app/api/admin/music/yt/clip/route.js
+++ b/src/app/api/admin/music/yt/clip/route.js
@@ -27,14 +27,26 @@ export async function POST(request) {
          body: JSON.stringify({ jobId, startSec }),
       });
    } catch (err) {
-      return NextResponse.json({ error: err.message }, { status: 500 });
+      console.error(
+         '[yt/clip] upstream fetch threw:',
+         err?.message,
+         err?.cause?.code || err?.cause || ''
+      );
+      return NextResponse.json(
+         { error: 'Failed to create snippet' },
+         { status: 500 }
+      );
    }
 
    const json = await res.json().catch(() => ({}));
    if (!res.ok) {
+      console.error('[yt/clip] upstream non-OK', res.status, json);
+      // 410 = the in-RAM job expired; surface it so the client can prompt a
+      // re-pick. Any other non-OK is a server-side failure → 500.
+      const status = res.status === 410 ? 410 : 500;
       return NextResponse.json(
          { error: json.error || 'Failed to create snippet' },
-         { status: res.status }
+         { status }
       );
    }
    return NextResponse.json(json);

--- a/src/app/api/admin/music/yt/clip/route.js
+++ b/src/app/api/admin/music/yt/clip/route.js
@@ -1,0 +1,36 @@
+import { NextResponse } from 'next/server';
+import { musicDlFetch } from '@/lib/musicDl';
+
+export const dynamic = 'force-dynamic';
+
+export async function POST(request) {
+   const body = await request.json().catch(() => ({}));
+   const { jobId, startSec } = body;
+
+   if (!jobId || typeof startSec !== 'number') {
+      return NextResponse.json(
+         { error: 'jobId and numeric startSec are required' },
+         { status: 400 }
+      );
+   }
+
+   let res;
+   try {
+      res = await musicDlFetch('/yt/clip', {
+         method: 'POST',
+         headers: { 'Content-Type': 'application/json' },
+         body: JSON.stringify({ jobId, startSec }),
+      });
+   } catch (err) {
+      return NextResponse.json({ error: err.message }, { status: 500 });
+   }
+
+   const json = await res.json().catch(() => ({}));
+   if (!res.ok) {
+      return NextResponse.json(
+         { error: json.error || 'Failed to create snippet' },
+         { status: res.status }
+      );
+   }
+   return NextResponse.json(json);
+}

--- a/src/app/api/admin/music/yt/prepare/route.js
+++ b/src/app/api/admin/music/yt/prepare/route.js
@@ -4,7 +4,12 @@ import { musicDlFetch } from '@/lib/musicDl';
 export const dynamic = 'force-dynamic';
 
 export async function POST(request) {
-   const body = await request.json().catch(() => ({}));
+   let body;
+   try {
+      body = await request.json();
+   } catch {
+      return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+   }
    const { videoId } = body;
 
    if (!videoId) {

--- a/src/app/api/admin/music/yt/prepare/route.js
+++ b/src/app/api/admin/music/yt/prepare/route.js
@@ -1,0 +1,33 @@
+import { NextResponse } from 'next/server';
+import { musicDlFetch } from '@/lib/musicDl';
+
+export const dynamic = 'force-dynamic';
+
+export async function POST(request) {
+   const body = await request.json().catch(() => ({}));
+   const { videoId } = body;
+
+   if (!videoId) {
+      return NextResponse.json({ error: 'videoId is required' }, { status: 400 });
+   }
+
+   let res;
+   try {
+      res = await musicDlFetch('/yt/prepare', {
+         method: 'POST',
+         headers: { 'Content-Type': 'application/json' },
+         body: JSON.stringify({ videoId }),
+      });
+   } catch (err) {
+      return NextResponse.json({ error: err.message }, { status: 500 });
+   }
+
+   const json = await res.json().catch(() => ({}));
+   if (!res.ok) {
+      return NextResponse.json(
+         { error: json.error || 'Failed to prepare audio' },
+         { status: res.status }
+      );
+   }
+   return NextResponse.json(json);
+}

--- a/src/app/api/admin/music/yt/prepare/route.js
+++ b/src/app/api/admin/music/yt/prepare/route.js
@@ -24,14 +24,24 @@ export async function POST(request) {
          body: JSON.stringify({ videoId }),
       });
    } catch (err) {
-      return NextResponse.json({ error: err.message }, { status: 500 });
+      console.error(
+         '[yt/prepare] upstream fetch threw:',
+         err?.message,
+         err?.cause?.code || err?.cause || ''
+      );
+      return NextResponse.json(
+         { error: 'Failed to prepare audio' },
+         { status: 500 }
+      );
    }
 
    const json = await res.json().catch(() => ({}));
    if (!res.ok) {
+      // Non-OK from our own service → surface 500, not the upstream status.
+      console.error('[yt/prepare] upstream non-OK', res.status, json);
       return NextResponse.json(
-         { error: json.error || 'Failed to prepare audio' },
-         { status: res.status }
+         { error: 'Failed to prepare audio' },
+         { status: 500 }
       );
    }
    return NextResponse.json(json);

--- a/src/app/api/admin/music/yt/search/route.js
+++ b/src/app/api/admin/music/yt/search/route.js
@@ -1,0 +1,32 @@
+import { NextResponse } from 'next/server';
+import { musicDlFetch } from '@/lib/musicDl';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(request) {
+   const { searchParams } = new URL(request.url);
+   const q = searchParams.get('q');
+   const limit = searchParams.get('limit') || '10';
+
+   if (!q || !q.trim()) {
+      return NextResponse.json({ results: [] });
+   }
+
+   let res;
+   try {
+      res = await musicDlFetch(
+         `/yt/search?q=${encodeURIComponent(q)}&limit=${encodeURIComponent(limit)}`
+      );
+   } catch (err) {
+      return NextResponse.json({ error: err.message }, { status: 500 });
+   }
+
+   const json = await res.json().catch(() => ({}));
+   if (!res.ok) {
+      return NextResponse.json(
+         { error: json.error || 'YouTube search failed' },
+         { status: res.status }
+      );
+   }
+   return NextResponse.json({ results: json.results || [] });
+}

--- a/src/app/api/admin/music/yt/search/route.js
+++ b/src/app/api/admin/music/yt/search/route.js
@@ -14,24 +14,27 @@ export async function GET(request) {
 
    let res;
    try {
-      res = await musicDlFetch(
-         `/yt/search?q=${encodeURIComponent(q)}&limit=${encodeURIComponent(limit)}`
-      );
+      res = await musicDlFetch('/yt/search', { params: { q, limit } });
    } catch (err) {
       console.error(
          '[yt/search] upstream fetch threw:',
          err?.message,
          err?.cause?.code || err?.cause || ''
       );
-      return NextResponse.json({ error: err.message }, { status: 500 });
+      return NextResponse.json(
+         { error: 'YouTube search failed' },
+         { status: 500 }
+      );
    }
 
    const json = await res.json().catch(() => ({}));
    if (!res.ok) {
+      // A non-OK from our own service is a server-side failure — surface 500,
+      // don't pass the upstream status (e.g. a 400) through to the client.
       console.error('[yt/search] upstream non-OK', res.status, json);
       return NextResponse.json(
-         { error: json.error || 'YouTube search failed' },
-         { status: res.status }
+         { error: 'YouTube search failed' },
+         { status: 500 }
       );
    }
    return NextResponse.json({ results: json.results || [] });

--- a/src/app/api/admin/music/yt/search/route.js
+++ b/src/app/api/admin/music/yt/search/route.js
@@ -18,11 +18,17 @@ export async function GET(request) {
          `/yt/search?q=${encodeURIComponent(q)}&limit=${encodeURIComponent(limit)}`
       );
    } catch (err) {
+      console.error(
+         '[yt/search] upstream fetch threw:',
+         err?.message,
+         err?.cause?.code || err?.cause || ''
+      );
       return NextResponse.json({ error: err.message }, { status: 500 });
    }
 
    const json = await res.json().catch(() => ({}));
    if (!res.ok) {
+      console.error('[yt/search] upstream non-OK', res.status, json);
       return NextResponse.json(
          { error: json.error || 'YouTube search failed' },
          { status: res.status }

--- a/src/app/api/get-song-of-the-day/route.js
+++ b/src/app/api/get-song-of-the-day/route.js
@@ -22,7 +22,7 @@ export const GET = async () => {
 
    const { data, error } = await supabase
       .from('song_of_the_day')
-      .select('date,title,artist,album,artwork_url,track_url,preview_url,deezer_id')
+      .select('date,title,artist,album,artwork_url,track_url,preview_url,deezer_id,snippet_url,source')
       .order('date', { ascending: false })
       .limit(1);
 
@@ -44,5 +44,7 @@ export const GET = async () => {
       track_url: song.track_url,
       preview_url: song.preview_url || null,
       deezer_id: song.deezer_id || null,
+      snippet_url: song.snippet_url || null,
+      source: song.source || 'deezer',
    });
 };

--- a/src/components/Admin/CalendarCell.jsx
+++ b/src/components/Admin/CalendarCell.jsx
@@ -87,7 +87,7 @@ const CalendarCell = ({
                      rel='noreferrer'
                      onClick={(e) => e.stopPropagation()}
                      className='w-8 h-8 rounded-full bg-white/20 hover:bg-white/30 flex items-center justify-center text-white transition-colors'
-                     aria-label='Open on Deezer'
+                     aria-label='Open original'
                   >
                      <LinkIcon />
                   </a>

--- a/src/components/Admin/MusicCalendar.jsx
+++ b/src/components/Admin/MusicCalendar.jsx
@@ -146,6 +146,15 @@ const MusicCalendar = ({ editable = true }) => {
       }
    };
 
+   const handleDelete = (date) => {
+      setSongs((prev) => {
+         const next = { ...prev };
+         delete next[date];
+         return next;
+      });
+      setSelectedDate(null);
+   };
+
    return (
       <div className='w-full max-w-[50rem] 2xl:max-w-[64rem] px-6 pb-8'>
          {/* Month navigation */}
@@ -226,6 +235,7 @@ const MusicCalendar = ({ editable = true }) => {
                existingSong={songs[selectedDate] || null}
                onSave={handleSave}
                onClose={() => setSelectedDate(null)}
+               onDelete={handleDelete}
             />
          )}
       </div>

--- a/src/components/Admin/MusicCalendar.jsx
+++ b/src/components/Admin/MusicCalendar.jsx
@@ -19,7 +19,9 @@ const MusicCalendar = ({ editable = true }) => {
    const { preload, clearCache, toggle, playing, playingId } = useAudioPreview();
 
    const resolvePreviewUrls = useCallback(async (songMap, id) => {
-      const toResolve = Object.values(songMap).filter((s) => s.deezer_id);
+      const toResolve = Object.values(songMap).filter(
+         (s) => s.deezer_id && !s.snippet_url
+      );
       if (toResolve.length === 0) return;
       try {
          const ids = toResolve.map((s) => s.deezer_id).join(',');
@@ -54,9 +56,15 @@ const MusicCalendar = ({ editable = true }) => {
          if (id !== fetchIdRef.current) return;
          const map = {};
          (json.songs || []).forEach((s) => {
-            map[s.date] = s;
-            // Legacy fallback: preload stored preview_url if no deezer_id
-            if (!s.deezer_id && s.preview_url) preload(s.preview_url);
+            if (s.snippet_url) {
+               // YouTube snippet: play the stored clip directly.
+               map[s.date] = { ...s, preview_url: s.snippet_url };
+               preload(s.snippet_url);
+            } else {
+               map[s.date] = s;
+               // Legacy fallback: preload stored preview_url if no deezer_id
+               if (!s.deezer_id && s.preview_url) preload(s.preview_url);
+            }
          });
          setSongs(map);
          // Resolve fresh preview URLs for songs with deezer_id
@@ -100,18 +108,35 @@ const MusicCalendar = ({ editable = true }) => {
    for (let d = 1; d <= daysInMonth; d++) cells.push(d);
 
    const handleSave = async (savedSong) => {
-      setSongs((prev) => ({ ...prev, [savedSong.date]: savedSong }));
       setSelectedDate(null);
-      // Resolve preview URL for the newly saved song
+      if (savedSong.snippet_url) {
+         // YouTube snippet: play the stored clip directly.
+         setSongs((prev) => ({
+            ...prev,
+            [savedSong.date]: {
+               ...savedSong,
+               preview_url: savedSong.snippet_url,
+            },
+         }));
+         preload(savedSong.snippet_url);
+         return;
+      }
+      setSongs((prev) => ({ ...prev, [savedSong.date]: savedSong }));
+      // Resolve preview URL for the newly saved Deezer song
       if (savedSong.deezer_id) {
          try {
-            const res = await fetch(`/api/music/preview?ids=${savedSong.deezer_id}`);
+            const res = await fetch(
+               `/api/music/preview?ids=${savedSong.deezer_id}`
+            );
             const json = await res.json();
             const url = json.previews?.[savedSong.deezer_id];
             if (url) {
                setSongs((prev) => ({
                   ...prev,
-                  [savedSong.date]: { ...prev[savedSong.date], preview_url: url },
+                  [savedSong.date]: {
+                     ...prev[savedSong.date],
+                     preview_url: url,
+                  },
                }));
                preload(url);
             }

--- a/src/components/Admin/MusicCalendar.jsx
+++ b/src/components/Admin/MusicCalendar.jsx
@@ -62,7 +62,7 @@ const MusicCalendar = ({ editable = true }) => {
                preload(s.snippet_url);
             } else {
                map[s.date] = s;
-               // Legacy fallback: preload stored preview_url if no deezer_id
+               // Non-Deezer song with a stored preview_url — preload it directly
                if (!s.deezer_id && s.preview_url) preload(s.preview_url);
             }
          });

--- a/src/components/Admin/MusicSearchModal.jsx
+++ b/src/components/Admin/MusicSearchModal.jsx
@@ -1,8 +1,10 @@
 'use client';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
+import YouTubeFlow from './YouTubeFlow';
 
 const MusicSearchModal = ({ date, existingSong, onSave, onClose }) => {
    const [songQuery, setSongQuery] = useState('');
+   const [source, setSource] = useState('deezer'); // 'deezer' | 'youtube'
    const [artistQuery, setArtistQuery] = useState('');
    const [artistSuggestions, setArtistSuggestions] = useState([]);
    const [selectedArtist, setSelectedArtist] = useState('');
@@ -168,6 +170,36 @@ const MusicSearchModal = ({ date, existingSong, onSave, onClose }) => {
                </button>
             </div>
 
+            {/* Source toggle */}
+            <div className='flex gap-1 bg-[#0f0f0f] border border-[#262626] rounded-lg p-1'>
+               <button
+                  type='button'
+                  onClick={() => setSource('deezer')}
+                  className={`flex-1 rounded-md py-1.5 text-xs font-semibold transition-colors ${
+                     source === 'deezer'
+                        ? 'bg-purple-500 text-white'
+                        : 'text-gray-400 hover:text-white'
+                  }`}
+               >
+                  Deezer
+               </button>
+               <button
+                  type='button'
+                  onClick={() => setSource('youtube')}
+                  className={`flex-1 rounded-md py-1.5 text-xs font-semibold transition-colors ${
+                     source === 'youtube'
+                        ? 'bg-purple-500 text-white'
+                        : 'text-gray-400 hover:text-white'
+                  }`}
+               >
+                  YouTube
+               </button>
+            </div>
+
+            {source === 'youtube' && (
+               <YouTubeFlow date={date} onSave={onSave} />
+            )}
+
             {/* Existing pick */}
             {existingSong && (
                <div className='flex items-center gap-3 p-3 rounded-lg bg-[#1a1a1a] border border-purple-500/40'>
@@ -190,145 +222,149 @@ const MusicSearchModal = ({ date, existingSong, onSave, onClose }) => {
                </div>
             )}
 
-            {/* Search fields */}
-            <div className='flex flex-col gap-2'>
-               {/* Artist combobox */}
-               <div className='relative'>
-                  <div className='relative flex items-center'>
-                     <input
-                        ref={artistInputRef}
-                        type='text'
-                        placeholder='Filter by artist (optional)'
-                        value={artistQuery}
-                        onChange={(e) => {
-                           setArtistQuery(e.target.value);
-                           setSelectedArtist('');
-                           setShowSuggestions(true);
-                        }}
-                        onFocus={() =>
-                           artistSuggestions.length > 0 &&
-                           setShowSuggestions(true)
-                        }
-                        className='w-full bg-[#1a1a1a] border border-[#303030] rounded-lg px-4 py-2 text-sm focus:outline-none focus:border-purple-500 transition-colors pr-8'
-                     />
-                     {artistQuery && (
-                        <button
-                           onClick={clearArtist}
-                           className='absolute right-2 text-gray-500 hover:text-white text-base leading-none'
-                           tabIndex={-1}
-                        >
-                           ×
-                        </button>
-                     )}
-                  </div>
+            {source === 'deezer' && (
+               <>
+                  {/* Search fields */}
+                  <div className='flex flex-col gap-2'>
+                     {/* Artist combobox */}
+                     <div className='relative'>
+                        <div className='relative flex items-center'>
+                           <input
+                              ref={artistInputRef}
+                              type='text'
+                              placeholder='Filter by artist (optional)'
+                              value={artistQuery}
+                              onChange={(e) => {
+                                 setArtistQuery(e.target.value);
+                                 setSelectedArtist('');
+                                 setShowSuggestions(true);
+                              }}
+                              onFocus={() =>
+                                 artistSuggestions.length > 0 &&
+                                 setShowSuggestions(true)
+                              }
+                              className='w-full bg-[#1a1a1a] border border-[#303030] rounded-lg px-4 py-2 text-sm focus:outline-none focus:border-purple-500 transition-colors pr-8'
+                           />
+                           {artistQuery && (
+                              <button
+                                 onClick={clearArtist}
+                                 className='absolute right-2 text-gray-500 hover:text-white text-base leading-none'
+                                 tabIndex={-1}
+                              >
+                                 ×
+                              </button>
+                           )}
+                        </div>
 
-                  {/* Suggestions dropdown */}
-                  {showSuggestions && artistSuggestions.length > 0 && (
-                     <ul
-                        ref={suggestionsRef}
-                        className='absolute z-10 w-full mt-1 bg-[#1a1a1a] border border-[#303030] rounded-lg overflow-hidden shadow-xl'
-                     >
-                        {artistSuggestions.map((name) => (
-                           <li
-                              key={name}
-                              onMouseDown={() => commitArtist(name)}
-                              className={`px-4 py-2 text-sm cursor-pointer transition-colors
+                        {/* Suggestions dropdown */}
+                        {showSuggestions && artistSuggestions.length > 0 && (
+                           <ul
+                              ref={suggestionsRef}
+                              className='absolute z-10 w-full mt-1 bg-[#1a1a1a] border border-[#303030] rounded-lg overflow-hidden shadow-xl'
+                           >
+                              {artistSuggestions.map((name) => (
+                                 <li
+                                    key={name}
+                                    onMouseDown={() => commitArtist(name)}
+                                    className={`px-4 py-2 text-sm cursor-pointer transition-colors
                       ${
                          selectedArtist === name
                             ? 'bg-purple-500/20 text-purple-300'
                             : 'hover:bg-[#242424] text-gray-200'
                       }`}
-                           >
-                              {name}
-                           </li>
-                        ))}
-                     </ul>
-                  )}
-               </div>
-
-               {/* Song title search */}
-               <input
-                  type='text'
-                  placeholder='Search for a song...'
-                  value={songQuery}
-                  onChange={(e) => setSongQuery(e.target.value)}
-                  className='w-full bg-[#1a1a1a] border border-[#303030] rounded-lg px-4 py-2 text-sm focus:outline-none focus:border-purple-500 transition-colors'
-                  autoFocus
-               />
-            </div>
-
-            {/* Save error */}
-            {saveError && (
-               <p className='text-sm text-red-400 text-center'>{saveError}</p>
-            )}
-
-            {/* Results */}
-            <div className='overflow-y-auto flex-1 min-h-0'>
-               {!songQuery.trim() && !selectedArtist && results.length === 0 && !searching && !saving ? (
-                  <div className='h-full flex flex-col items-center justify-center gap-3 text-gray-500'>
-                     <svg className='w-12 h-12 opacity-40' fill='none' viewBox='0 0 24 24' stroke='currentColor' strokeWidth={1.5}>
-                        <path strokeLinecap='round' strokeLinejoin='round' d='m9 9 10.5-3m0 6.553v3.75a2.25 2.25 0 0 1-1.632 2.163l-1.32.377a1.803 1.803 0 1 1-.99-3.467l2.31-.66a2.25 2.25 0 0 0 1.632-2.163Zm0 0V2.25L9 5.25v10.303m0 0v3.75a2.25 2.25 0 0 1-1.632 2.163l-1.32.377a1.803 1.803 0 0 1-.99-3.467l2.31-.66A2.25 2.25 0 0 0 9 15.553Z' />
-                     </svg>
-                     <p className='text-sm'>Search for a song or filter by artist</p>
-                     <p className='text-xs text-gray-600'>Results will appear here</p>
-                  </div>
-               ) : (
-                  <>
-                     {searching && (
-                        <p className='text-center text-gray-500 text-sm py-4'>
-                           Searching...
-                        </p>
-                     )}
-                     {saving && (
-                        <p className='text-center text-gray-500 text-sm py-4'>
-                           Saving...
-                        </p>
-                     )}
-                     {!searching &&
-                        !saving &&
-                        results.length === 0 &&
-                        (songQuery.trim() || selectedArtist) && (
-                           <p className='text-center text-gray-500 text-sm py-4'>
-                              No results found.
-                           </p>
-                        )}
-                     {!searching && !saving && (
-                        <>
-                           <div className='grid grid-cols-3 gap-2'>
-                              {results.map((song) => (
-                                 <button
-                                    key={song.id}
-                                    onClick={() => handlePick(song)}
-                                    className='flex flex-col items-center gap-1 p-2 rounded-lg bg-[#1a1a1a] hover:bg-[#242424] transition-colors text-left group'
                                  >
-                                    <img
-                                       src={song.artwork_url}
-                                       alt={song.title}
-                                       className='w-full aspect-square object-cover rounded'
-                                    />
-                                    <p className='text-xs font-medium w-full truncate group-hover:text-purple-300 transition-colors'>
-                                       {song.title}
-                                    </p>
-                                    <p className='text-xs text-gray-500 w-full truncate'>
-                                       {song.artist}
-                                    </p>
-                                 </button>
+                                    {name}
+                                 </li>
                               ))}
-                           </div>
-                           {hasMore && (
-                              <button
-                                 onClick={loadMore}
-                                 disabled={loadingMore}
-                                 className='w-full mt-3 py-2 rounded-lg bg-[#1a1a1a] border border-[#303030] text-sm text-gray-400 hover:text-white hover:border-purple-500/40 transition-colors disabled:opacity-50'
-                              >
-                                 {loadingMore ? 'Loading...' : 'Load more'}
-                              </button>
+                           </ul>
+                        )}
+                     </div>
+
+                     {/* Song title search */}
+                     <input
+                        type='text'
+                        placeholder='Search for a song...'
+                        value={songQuery}
+                        onChange={(e) => setSongQuery(e.target.value)}
+                        className='w-full bg-[#1a1a1a] border border-[#303030] rounded-lg px-4 py-2 text-sm focus:outline-none focus:border-purple-500 transition-colors'
+                        autoFocus
+                     />
+                  </div>
+
+                  {/* Save error */}
+                  {saveError && (
+                     <p className='text-sm text-red-400 text-center'>{saveError}</p>
+                  )}
+
+                  {/* Results */}
+                  <div className='overflow-y-auto flex-1 min-h-0'>
+                     {!songQuery.trim() && !selectedArtist && results.length === 0 && !searching && !saving ? (
+                        <div className='h-full flex flex-col items-center justify-center gap-3 text-gray-500'>
+                           <svg className='w-12 h-12 opacity-40' fill='none' viewBox='0 0 24 24' stroke='currentColor' strokeWidth={1.5}>
+                              <path strokeLinecap='round' strokeLinejoin='round' d='m9 9 10.5-3m0 6.553v3.75a2.25 2.25 0 0 1-1.632 2.163l-1.32.377a1.803 1.803 0 1 1-.99-3.467l2.31-.66a2.25 2.25 0 0 0 1.632-2.163Zm0 0V2.25L9 5.25v10.303m0 0v3.75a2.25 2.25 0 0 1-1.632 2.163l-1.32.377a1.803 1.803 0 0 1-.99-3.467l2.31-.66A2.25 2.25 0 0 0 9 15.553Z' />
+                           </svg>
+                           <p className='text-sm'>Search for a song or filter by artist</p>
+                           <p className='text-xs text-gray-600'>Results will appear here</p>
+                        </div>
+                     ) : (
+                        <>
+                           {searching && (
+                              <p className='text-center text-gray-500 text-sm py-4'>
+                                 Searching...
+                              </p>
+                           )}
+                           {saving && (
+                              <p className='text-center text-gray-500 text-sm py-4'>
+                                 Saving...
+                              </p>
+                           )}
+                           {!searching &&
+                              !saving &&
+                              results.length === 0 &&
+                              (songQuery.trim() || selectedArtist) && (
+                                 <p className='text-center text-gray-500 text-sm py-4'>
+                                    No results found.
+                                 </p>
+                              )}
+                           {!searching && !saving && (
+                              <>
+                                 <div className='grid grid-cols-3 gap-2'>
+                                    {results.map((song) => (
+                                       <button
+                                          key={song.id}
+                                          onClick={() => handlePick(song)}
+                                          className='flex flex-col items-center gap-1 p-2 rounded-lg bg-[#1a1a1a] hover:bg-[#242424] transition-colors text-left group'
+                                       >
+                                          <img
+                                             src={song.artwork_url}
+                                             alt={song.title}
+                                             className='w-full aspect-square object-cover rounded'
+                                          />
+                                          <p className='text-xs font-medium w-full truncate group-hover:text-purple-300 transition-colors'>
+                                             {song.title}
+                                          </p>
+                                          <p className='text-xs text-gray-500 w-full truncate'>
+                                             {song.artist}
+                                          </p>
+                                       </button>
+                                    ))}
+                                 </div>
+                                 {hasMore && (
+                                    <button
+                                       onClick={loadMore}
+                                       disabled={loadingMore}
+                                       className='w-full mt-3 py-2 rounded-lg bg-[#1a1a1a] border border-[#303030] text-sm text-gray-400 hover:text-white hover:border-purple-500/40 transition-colors disabled:opacity-50'
+                                    >
+                                       {loadingMore ? 'Loading...' : 'Load more'}
+                                    </button>
+                                 )}
+                              </>
                            )}
                         </>
                      )}
-                  </>
-               )}
-            </div>
+                  </div>
+               </>
+            )}
          </div>
       </div>
    );

--- a/src/components/Admin/MusicSearchModal.jsx
+++ b/src/components/Admin/MusicSearchModal.jsx
@@ -2,9 +2,12 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import YouTubeFlow from './YouTubeFlow';
 
-const MusicSearchModal = ({ date, existingSong, onSave, onClose }) => {
+const MusicSearchModal = ({ date, existingSong, onSave, onClose, onDelete }) => {
    const [songQuery, setSongQuery] = useState('');
    const [source, setSource] = useState('deezer'); // 'deezer' | 'youtube'
+   const [confirmingDelete, setConfirmingDelete] = useState(false);
+   const [deleting, setDeleting] = useState(false);
+   const [deleteError, setDeleteError] = useState(null);
    const [artistQuery, setArtistQuery] = useState('');
    const [artistSuggestions, setArtistSuggestions] = useState([]);
    const [selectedArtist, setSelectedArtist] = useState('');
@@ -147,6 +150,27 @@ const MusicSearchModal = ({ date, existingSong, onSave, onClose }) => {
       }
    };
 
+   const handleRemove = async () => {
+      setDeleting(true);
+      setDeleteError(null);
+      try {
+         const res = await fetch(
+            `/api/admin/music?date=${encodeURIComponent(date)}`,
+            { method: 'DELETE' }
+         );
+         const json = await res.json().catch(() => ({}));
+         if (!res.ok) {
+            setDeleteError(json.error || 'Failed to remove song.');
+            return;
+         }
+         onDelete(date);
+      } catch {
+         setDeleteError('Network error while removing song.');
+      } finally {
+         setDeleting(false);
+      }
+   };
+
    return (
       <div
          className='fixed inset-0 z-50 flex items-center justify-center bg-black/70'
@@ -202,23 +226,79 @@ const MusicSearchModal = ({ date, existingSong, onSave, onClose }) => {
 
             {/* Existing pick */}
             {existingSong && (
-               <div className='flex items-center gap-3 p-3 rounded-lg bg-[#1a1a1a] border border-purple-500/40'>
-                  <img
-                     src={existingSong.artwork_url}
-                     alt={existingSong.title}
-                     className='w-12 h-12 rounded object-cover flex-shrink-0'
-                  />
-                  <div className='flex-1 min-w-0'>
-                     <p className='text-sm font-medium truncate'>
-                        {existingSong.title}
-                     </p>
-                     <p className='text-xs text-gray-400 truncate'>
-                        {existingSong.artist}
-                     </p>
+               <div className='flex flex-col gap-2 p-3 rounded-lg bg-[#1a1a1a] border border-purple-500/40'>
+                  <div className='flex items-center gap-3'>
+                     <img
+                        src={existingSong.artwork_url}
+                        alt={existingSong.title}
+                        className='w-12 h-12 rounded object-cover flex-shrink-0'
+                     />
+                     <div className='flex-1 min-w-0'>
+                        <p className='text-sm font-medium truncate'>
+                           {existingSong.title}
+                        </p>
+                        <p className='text-xs text-gray-400 truncate'>
+                           {existingSong.artist}
+                        </p>
+                     </div>
+                     {!confirmingDelete && (
+                        <button
+                           type='button'
+                           onClick={() => {
+                              setDeleteError(null);
+                              setConfirmingDelete(true);
+                           }}
+                           className='flex-shrink-0 p-1 text-gray-400 hover:text-red-400 transition-colors'
+                           aria-label='Remove song'
+                           title='Remove song'
+                        >
+                           <svg
+                              xmlns='http://www.w3.org/2000/svg'
+                              className='w-4 h-4'
+                              fill='none'
+                              viewBox='0 0 24 24'
+                              stroke='currentColor'
+                              strokeWidth={2}
+                           >
+                              <path
+                                 strokeLinecap='round'
+                                 strokeLinejoin='round'
+                                 d='M6 7h12M9 7V5a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2m-7 0v12a1 1 0 0 0 1 1h6a1 1 0 0 0 1-1V7'
+                              />
+                           </svg>
+                        </button>
+                     )}
                   </div>
-                  <span className='text-xs text-purple-400 flex-shrink-0'>
-                     Current pick
-                  </span>
+
+                  {confirmingDelete && (
+                     <div className='flex items-center justify-between gap-2 pt-1'>
+                        <span className='text-xs text-gray-300'>
+                           Remove this song? This deletes the saved snippet.
+                        </span>
+                        <div className='flex gap-2 flex-shrink-0'>
+                           <button
+                              type='button'
+                              onClick={() => setConfirmingDelete(false)}
+                              disabled={deleting}
+                              className='text-xs px-2 py-1 rounded bg-[#242424] text-gray-300 hover:text-white disabled:opacity-50'
+                           >
+                              Cancel
+                           </button>
+                           <button
+                              type='button'
+                              onClick={handleRemove}
+                              disabled={deleting}
+                              className='text-xs px-2 py-1 rounded bg-red-600 hover:bg-red-500 text-white disabled:opacity-50'
+                           >
+                              {deleting ? 'Removing…' : 'Remove'}
+                           </button>
+                        </div>
+                     </div>
+                  )}
+
+                  {deleteError && (
+                     <p className='text-xs text-red-400'>{deleteError}</p>
+                  )}
                </div>
             )}
 

--- a/src/components/Admin/MusicSearchModal.jsx
+++ b/src/components/Admin/MusicSearchModal.jsx
@@ -174,12 +174,14 @@ const MusicSearchModal = ({ date, existingSong, onSave, onClose, onDelete }) => 
    return (
       <div
          className='fixed inset-0 z-50 flex items-center justify-center bg-black/70'
-         onClick={onClose}
+         onMouseDown={(e) => {
+            // Close only on a deliberate press that starts on the backdrop —
+            // not when a drag (e.g. scrubbing the waveform) is released outside
+            // the modal, which would otherwise fire a click on this backdrop.
+            if (e.target === e.currentTarget) onClose();
+         }}
       >
-         <div
-            className='bg-[#151515] rounded-xl w-full max-w-lg mx-4 p-5 flex flex-col gap-4 h-[80vh]'
-            onClick={(e) => e.stopPropagation()}
-         >
+         <div className='bg-[#151515] rounded-xl w-full max-w-lg mx-4 p-5 flex flex-col gap-4 h-[80vh]'>
             {/* Header */}
             <div className='flex items-center justify-between'>
                <h3 className='text-lg font-semibold'>

--- a/src/components/Admin/MusicSearchModal.jsx
+++ b/src/components/Admin/MusicSearchModal.jsx
@@ -80,9 +80,8 @@ const MusicSearchModal = ({ date, existingSong, onSave, onClose, onDelete }) => 
          return;
       }
       const id = ++artistReqIdRef.current;
-      const res = await fetch(
-         `/api/admin/music/search?mode=artists&q=${encodeURIComponent(q)}`
-      );
+      const params = new URLSearchParams({ mode: 'artists', q });
+      const res = await fetch(`/api/admin/music/search?${params}`);
       const json = await res.json();
       if (id !== artistReqIdRef.current) return; // stale response
       setArtistSuggestions(json.artists || []);

--- a/src/components/Admin/MusicSearchModal.jsx
+++ b/src/components/Admin/MusicSearchModal.jsx
@@ -5,6 +5,13 @@ import YouTubeFlow from './YouTubeFlow';
 const MusicSearchModal = ({ date, existingSong, onSave, onClose, onDelete }) => {
    const [songQuery, setSongQuery] = useState('');
    const [source, setSource] = useState('deezer'); // 'deezer' | 'youtube'
+   // YouTube authoring needs the local music-dl-service, so the tab is only
+   // available when the site runs on localhost — never in production.
+   const [isLocalhost, setIsLocalhost] = useState(false);
+   useEffect(() => {
+      const h = window.location.hostname;
+      setIsLocalhost(h === 'localhost' || h === '127.0.0.1' || h === '::1');
+   }, []);
    const [confirmingDelete, setConfirmingDelete] = useState(false);
    const [deleting, setDeleting] = useState(false);
    const [deleteError, setDeleteError] = useState(null);
@@ -195,33 +202,35 @@ const MusicSearchModal = ({ date, existingSong, onSave, onClose, onDelete }) => 
                </button>
             </div>
 
-            {/* Source toggle */}
-            <div className='flex gap-1 bg-[#0f0f0f] border border-[#262626] rounded-lg p-1'>
-               <button
-                  type='button'
-                  onClick={() => setSource('deezer')}
-                  className={`flex-1 rounded-md py-1.5 text-xs font-semibold transition-colors ${
-                     source === 'deezer'
-                        ? 'bg-purple-500 text-white'
-                        : 'text-gray-400 hover:text-white'
-                  }`}
-               >
-                  Deezer
-               </button>
-               <button
-                  type='button'
-                  onClick={() => setSource('youtube')}
-                  className={`flex-1 rounded-md py-1.5 text-xs font-semibold transition-colors ${
-                     source === 'youtube'
-                        ? 'bg-purple-500 text-white'
-                        : 'text-gray-400 hover:text-white'
-                  }`}
-               >
-                  YouTube
-               </button>
-            </div>
+            {/* Source toggle — YouTube tab only on localhost (needs the local service) */}
+            {isLocalhost && (
+               <div className='flex gap-1 bg-[#0f0f0f] border border-[#262626] rounded-lg p-1'>
+                  <button
+                     type='button'
+                     onClick={() => setSource('deezer')}
+                     className={`flex-1 rounded-md py-1.5 text-xs font-semibold transition-colors ${
+                        source === 'deezer'
+                           ? 'bg-purple-500 text-white'
+                           : 'text-gray-400 hover:text-white'
+                     }`}
+                  >
+                     Deezer
+                  </button>
+                  <button
+                     type='button'
+                     onClick={() => setSource('youtube')}
+                     className={`flex-1 rounded-md py-1.5 text-xs font-semibold transition-colors ${
+                        source === 'youtube'
+                           ? 'bg-purple-500 text-white'
+                           : 'text-gray-400 hover:text-white'
+                     }`}
+                  >
+                     YouTube
+                  </button>
+               </div>
+            )}
 
-            {source === 'youtube' && (
+            {isLocalhost && source === 'youtube' && (
                <YouTubeFlow date={date} onSave={onSave} />
             )}
 

--- a/src/components/Admin/SnippetPicker.jsx
+++ b/src/components/Admin/SnippetPicker.jsx
@@ -1,0 +1,234 @@
+'use client';
+import React, { useEffect, useRef, useState } from 'react';
+import useWaveform from './useWaveform';
+import { PlayIcon, PauseIcon } from '../icons/AudioIcons';
+
+const CLIP = 15; // seconds
+
+function fmt(s) {
+   s = Math.max(0, Math.round(s || 0));
+   const m = Math.floor(s / 60);
+   const r = s % 60;
+   return `${m}:${String(r).padStart(2, '0')}`;
+}
+
+const SnippetPicker = ({
+   audioUrl,
+   durationSec,
+   title,
+   channel,
+   thumbnail,
+   clipping,
+   onConfirm,
+   onBack,
+}) => {
+   const { peaks, duration: wfDuration, loading, error } = useWaveform(audioUrl);
+   const duration = wfDuration || durationSec || 0;
+   const maxStart = Math.max(0, duration - CLIP);
+   const clipLen = Math.min(CLIP, duration || CLIP);
+
+   const [startSec, setStartSec] = useState(0);
+   const [playing, setPlaying] = useState(false);
+   const [cursor, setCursor] = useState(0);
+
+   const audioRef = useRef(null);
+   const trackRef = useRef(null);
+   const draggingRef = useRef(false);
+
+   // Clamp the window start once the real duration is known.
+   useEffect(() => {
+      setStartSec((s) => Math.min(s, maxStart));
+   }, [maxStart]);
+
+   const windowPct = duration ? (clipLen / duration) * 100 : 100;
+   const leftPct = duration ? (startSec / duration) * 100 : 0;
+
+   const seekFromClientX = (clientX) => {
+      const el = trackRef.current;
+      if (!el || !duration) return;
+      const rect = el.getBoundingClientRect();
+      const ratio = (clientX - rect.left) / rect.width;
+      const newStart = Math.max(0, Math.min(maxStart, ratio * duration));
+      setStartSec(newStart);
+      if (audioRef.current) audioRef.current.currentTime = newStart;
+   };
+
+   const onPointerDown = (e) => {
+      draggingRef.current = true;
+      seekFromClientX(e.clientX);
+      e.preventDefault();
+   };
+
+   useEffect(() => {
+      const move = (e) => {
+         if (draggingRef.current) seekFromClientX(e.clientX);
+      };
+      const up = () => {
+         draggingRef.current = false;
+      };
+      window.addEventListener('pointermove', move);
+      window.addEventListener('pointerup', up);
+      return () => {
+         window.removeEventListener('pointermove', move);
+         window.removeEventListener('pointerup', up);
+      };
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+   }, [maxStart, duration]);
+
+   const togglePlay = () => {
+      const audio = audioRef.current;
+      if (!audio) return;
+      if (playing) {
+         audio.pause();
+         setPlaying(false);
+      } else {
+         audio.currentTime = startSec;
+         audio
+            .play()
+            .then(() => setPlaying(true))
+            .catch(() => setPlaying(false));
+      }
+   };
+
+   // Loop playback within [startSec, startSec + clipLen] and drive the playhead.
+   useEffect(() => {
+      const audio = audioRef.current;
+      if (!audio) return;
+      const onTime = () => {
+         setCursor(audio.currentTime);
+         if (audio.currentTime >= startSec + clipLen) {
+            audio.currentTime = startSec;
+         }
+      };
+      const onEnded = () => setPlaying(false);
+      audio.addEventListener('timeupdate', onTime);
+      audio.addEventListener('ended', onEnded);
+      return () => {
+         audio.removeEventListener('timeupdate', onTime);
+         audio.removeEventListener('ended', onEnded);
+      };
+   }, [startSec, clipLen]);
+
+   useEffect(() => {
+      const audio = audioRef.current;
+      return () => {
+         if (audio) audio.pause();
+      };
+   }, []);
+
+   const playheadPct = duration && playing ? (cursor / duration) * 100 : null;
+
+   return (
+      <div className='flex flex-col gap-3'>
+         <audio ref={audioRef} src={audioUrl} preload='auto' />
+
+         {/* Header */}
+         <div className='flex items-center gap-3'>
+            {thumbnail && (
+               <img
+                  src={thumbnail}
+                  alt={title}
+                  className='w-12 h-12 rounded object-cover flex-shrink-0'
+               />
+            )}
+            <div className='flex-1 min-w-0'>
+               <p className='text-sm font-medium truncate'>{title}</p>
+               <p className='text-xs text-gray-400 truncate'>{channel}</p>
+            </div>
+            <button
+               type='button'
+               onClick={togglePlay}
+               disabled={loading || !!error}
+               className='w-10 h-10 rounded-full bg-purple-500 hover:bg-purple-400 disabled:opacity-40 flex items-center justify-center text-white flex-shrink-0'
+               aria-label={playing ? 'Pause preview' : 'Play preview'}
+            >
+               {playing ? <PauseIcon /> : <PlayIcon />}
+            </button>
+         </div>
+
+         {/* Waveform */}
+         <div
+            ref={trackRef}
+            onPointerDown={onPointerDown}
+            className='relative h-24 bg-[#0f0f0f] rounded-lg overflow-hidden cursor-grab select-none'
+         >
+            {loading ? (
+               <div className='absolute inset-0 flex items-center justify-center text-xs text-gray-500'>
+                  Analyzing audio…
+               </div>
+            ) : error ? (
+               <div className='absolute inset-0 flex items-center justify-center text-xs text-red-400 px-3 text-center'>
+                  {error}
+               </div>
+            ) : (
+               <>
+                  <div className='absolute inset-0 flex items-center gap-[2px] px-1'>
+                     {peaks.map((p, i) => {
+                        const barStart = (i / peaks.length) * 100;
+                        const inWindow =
+                           barStart >= leftPct && barStart <= leftPct + windowPct;
+                        return (
+                           <div
+                              key={i}
+                              className={`flex-1 rounded-sm ${
+                                 inWindow ? 'bg-purple-400' : 'bg-[#3a3a3a]'
+                              }`}
+                              style={{ height: `${Math.max(6, p * 100)}%` }}
+                           />
+                        );
+                     })}
+                  </div>
+                  <div
+                     className='absolute top-0 bottom-0 border-2 border-purple-500 rounded-md bg-purple-500/10 pointer-events-none'
+                     style={{ left: `${leftPct}%`, width: `${windowPct}%` }}
+                  />
+                  {playheadPct != null && (
+                     <div
+                        className='absolute top-0 bottom-0 w-[2px] bg-white pointer-events-none'
+                        style={{ left: `${playheadPct}%` }}
+                     />
+                  )}
+               </>
+            )}
+         </div>
+
+         {/* Ruler */}
+         <div className='flex justify-between text-[10px] text-gray-500 tabular-nums'>
+            <span>0:00</span>
+            <span>{fmt(duration * 0.25)}</span>
+            <span>{fmt(duration * 0.5)}</span>
+            <span>{fmt(duration * 0.75)}</span>
+            <span>{fmt(duration)}</span>
+         </div>
+
+         <div className='text-center text-xs text-gray-300'>
+            Snippet:{' '}
+            <span className='tabular-nums'>
+               {fmt(startSec)} → {fmt(startSec + clipLen)}
+            </span>{' '}
+            · {Math.round(clipLen)}s
+         </div>
+
+         {/* Actions */}
+         <div className='flex gap-2'>
+            <button
+               type='button'
+               onClick={onBack}
+               className='px-4 py-2 rounded-lg bg-[#1a1a1a] border border-[#303030] text-sm text-gray-300 hover:text-white'
+            >
+               Back
+            </button>
+            <button
+               type='button'
+               onClick={() => onConfirm(startSec)}
+               disabled={loading || !!error || clipping}
+               className='flex-1 py-2 rounded-lg bg-purple-500 hover:bg-purple-400 disabled:opacity-50 text-white font-semibold text-sm'
+            >
+               {clipping ? 'Saving snippet…' : 'Use this snippet →'}
+            </button>
+         </div>
+      </div>
+   );
+};
+
+export default SnippetPicker;

--- a/src/components/Admin/SnippetPicker.jsx
+++ b/src/components/Admin/SnippetPicker.jsx
@@ -1,9 +1,12 @@
 'use client';
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import useWaveform from './useWaveform';
 import { PlayIcon, PauseIcon } from '../icons/AudioIcons';
 
 const CLIP = 15; // seconds
+const BARS_PER_SEC = 6;
+
+const clamp = (v, lo, hi) => Math.max(lo, Math.min(hi, v));
 
 function fmt(s) {
    s = Math.max(0, Math.round(s || 0));
@@ -22,49 +25,93 @@ const SnippetPicker = ({
    onConfirm,
    onBack,
 }) => {
-   const { peaks, duration: wfDuration, loading, error } = useWaveform(audioUrl);
-   const duration = wfDuration || durationSec || 0;
-   const maxStart = Math.max(0, duration - CLIP);
-   const clipLen = Math.min(CLIP, duration || CLIP);
+   // Resolution for the zoomed waveform — finer than the old 64 bars.
+   // Derived from the prepared durationSec so it's known before decode.
+   const barCount = useMemo(
+      () => clamp(Math.round((durationSec || 60) * BARS_PER_SEC), 64, 2000),
+      [durationSec]
+   );
+   const { peaks, duration: wfDuration, loading, error } = useWaveform(
+      audioUrl,
+      barCount
+   );
 
-   const [startSec, setStartSec] = useState(0);
+   const duration = wfDuration || durationSec || 0;
+   const clipLen = Math.min(CLIP, duration || CLIP);
+   const maxStart = Math.max(0, duration - CLIP);
+
+   const [start, setStart] = useState(0);
    const [playing, setPlaying] = useState(false);
    const [cursor, setCursor] = useState(0);
+   const [trackWidth, setTrackWidth] = useState(0);
 
    const audioRef = useRef(null);
    const trackRef = useRef(null);
-   const draggingRef = useRef(false);
+   const dragRef = useRef(null); // { startX, startAt } while dragging
 
-   // Clamp the window start once the real duration is known.
+   // Measure the track width (responsive zoom) + keep it current on resize.
    useEffect(() => {
-      setStartSec((s) => Math.min(s, maxStart));
+      const el = trackRef.current;
+      if (!el) return;
+      const update = () => setTrackWidth(el.clientWidth);
+      update();
+      const ro = new ResizeObserver(update);
+      ro.observe(el);
+      return () => ro.disconnect();
+   }, []);
+
+   // Clamp the start once the real duration is known.
+   useEffect(() => {
+      setStart((s) => clamp(s, 0, maxStart));
    }, [maxStart]);
 
-   const windowPct = duration ? (clipLen / duration) * 100 : 100;
-   const leftPct = duration ? (startSec / duration) * 100 : 0;
+   const pxPerSec = trackWidth ? trackWidth / 2 / CLIP : 0;
+   const stripWidth = duration * pxPerSec;
+   const center = trackWidth / 2;
+   const translateX = center - start * pxPerSec;
+   const canDrag = !loading && !error && maxStart > 0;
+   const highlightWidth = clipLen * pxPerSec;
 
-   const seekFromClientX = (clientX) => {
-      const el = trackRef.current;
-      if (!el || !duration) return;
-      const rect = el.getBoundingClientRect();
-      const ratio = (clientX - rect.left) / rect.width;
-      const newStart = Math.max(0, Math.min(maxStart, ratio * duration));
-      setStartSec(newStart);
-      if (audioRef.current) audioRef.current.currentTime = newStart;
+   // Memoize the bars so scrubbing (start change) doesn't rebuild them.
+   const bars = useMemo(() => {
+      if (!peaks.length || !stripWidth) return null;
+      return (
+         <div
+            className='absolute top-0 bottom-0 left-0 flex items-center gap-[1px]'
+            style={{ width: `${stripWidth}px` }}
+         >
+            {peaks.map((p, i) => (
+               <div
+                  key={i}
+                  className='flex-1 rounded-sm bg-[#4a4a4a]'
+                  style={{ height: `${Math.max(6, p * 100)}%` }}
+               />
+            ))}
+         </div>
+      );
+   }, [peaks, stripWidth]);
+
+   const seekTo = (next) => {
+      const v = clamp(next, 0, maxStart);
+      setStart(v);
+      if (audioRef.current) audioRef.current.currentTime = v;
    };
 
    const onPointerDown = (e) => {
-      draggingRef.current = true;
-      seekFromClientX(e.clientX);
+      if (!canDrag) return;
+      dragRef.current = { startX: e.clientX, startAt: start };
       e.preventDefault();
    };
 
+   // Window-level drag listeners so the gesture continues outside the track.
    useEffect(() => {
       const move = (e) => {
-         if (draggingRef.current) seekFromClientX(e.clientX);
+         if (!dragRef.current || !pxPerSec) return;
+         const delta = e.clientX - dragRef.current.startX;
+         seekTo(dragRef.current.startAt - delta / pxPerSec);
       };
       const up = () => {
-         draggingRef.current = false;
+         dragRef.current = null;
       };
       window.addEventListener('pointermove', move);
       window.addEventListener('pointerup', up);
@@ -73,7 +120,7 @@ const SnippetPicker = ({
          window.removeEventListener('pointerup', up);
       };
       // eslint-disable-next-line react-hooks/exhaustive-deps
-   }, [maxStart, duration]);
+   }, [pxPerSec, maxStart]);
 
    const togglePlay = () => {
       const audio = audioRef.current;
@@ -82,7 +129,7 @@ const SnippetPicker = ({
          audio.pause();
          setPlaying(false);
       } else {
-         audio.currentTime = startSec;
+         audio.currentTime = start;
          audio
             .play()
             .then(() => setPlaying(true))
@@ -90,14 +137,14 @@ const SnippetPicker = ({
       }
    };
 
-   // Loop playback within [startSec, startSec + clipLen] and drive the playhead.
+   // Loop preview within [start, start + clipLen] and drive the playhead.
    useEffect(() => {
       const audio = audioRef.current;
       if (!audio) return;
       const onTime = () => {
          setCursor(audio.currentTime);
-         if (audio.currentTime >= startSec + clipLen) {
-            audio.currentTime = startSec;
+         if (audio.currentTime >= start + clipLen) {
+            audio.currentTime = start;
          }
       };
       const onEnded = () => setPlaying(false);
@@ -107,8 +154,9 @@ const SnippetPicker = ({
          audio.removeEventListener('timeupdate', onTime);
          audio.removeEventListener('ended', onEnded);
       };
-   }, [startSec, clipLen]);
+   }, [start, clipLen]);
 
+   // Stop audio on unmount.
    useEffect(() => {
       const audio = audioRef.current;
       return () => {
@@ -116,7 +164,8 @@ const SnippetPicker = ({
       };
    }, []);
 
-   const playheadPct = duration && playing ? (cursor / duration) * 100 : null;
+   const playheadX =
+      playing && pxPerSec ? center + (cursor - start) * pxPerSec : null;
 
    return (
       <div className='flex flex-col gap-3'>
@@ -146,11 +195,13 @@ const SnippetPicker = ({
             </button>
          </div>
 
-         {/* Waveform */}
+         {/* Zoomed, scrolling waveform track */}
          <div
             ref={trackRef}
             onPointerDown={onPointerDown}
-            className='relative h-24 bg-[#0f0f0f] rounded-lg overflow-hidden cursor-grab select-none'
+            className={`relative h-24 bg-[#0f0f0f] rounded-lg overflow-hidden select-none ${
+               canDrag ? 'cursor-grab active:cursor-grabbing' : ''
+            }`}
          >
             {loading ? (
                <div className='absolute inset-0 flex items-center justify-center text-xs text-gray-500'>
@@ -162,49 +213,39 @@ const SnippetPicker = ({
                </div>
             ) : (
                <>
-                  <div className='absolute inset-0 flex items-center gap-[2px] px-1'>
-                     {peaks.map((p, i) => {
-                        const barStart = (i / peaks.length) * 100;
-                        const inWindow =
-                           barStart >= leftPct && barStart <= leftPct + windowPct;
-                        return (
-                           <div
-                              key={i}
-                              className={`flex-1 rounded-sm ${
-                                 inWindow ? 'bg-purple-400' : 'bg-[#3a3a3a]'
-                              }`}
-                              style={{ height: `${Math.max(6, p * 100)}%` }}
-                           />
-                        );
-                     })}
-                  </div>
+                  {/* Scrolling strip (only transform changes while scrubbing) */}
                   <div
-                     className='absolute top-0 bottom-0 border-2 border-purple-500 rounded-md bg-purple-500/10 pointer-events-none'
-                     style={{ left: `${leftPct}%`, width: `${windowPct}%` }}
+                     className='absolute top-0 bottom-0 left-0 will-change-transform'
+                     style={{ transform: `translateX(${translateX}px)` }}
+                  >
+                     {bars}
+                  </div>
+
+                  {/* Fixed 15s highlight: center -> right edge */}
+                  <div
+                     className='absolute top-0 bottom-0 bg-purple-500/15 border-r border-purple-500/50 pointer-events-none'
+                     style={{ left: `${center}px`, width: `${highlightWidth}px` }}
                   />
-                  {playheadPct != null && (
+                  {/* Fixed center start line */}
+                  <div
+                     className='absolute top-0 bottom-0 w-[2px] bg-purple-400 pointer-events-none'
+                     style={{ left: `${center}px` }}
+                  />
+                  {/* Playhead (during preview) */}
+                  {playheadX != null && (
                      <div
-                        className='absolute top-0 bottom-0 w-[2px] bg-white pointer-events-none'
-                        style={{ left: `${playheadPct}%` }}
+                        className='absolute top-0 bottom-0 w-[2px] bg-white/90 pointer-events-none'
+                        style={{ left: `${playheadX}px` }}
                      />
                   )}
                </>
             )}
          </div>
 
-         {/* Ruler */}
-         <div className='flex justify-between text-[10px] text-gray-500 tabular-nums'>
-            <span>0:00</span>
-            <span>{fmt(duration * 0.25)}</span>
-            <span>{fmt(duration * 0.5)}</span>
-            <span>{fmt(duration * 0.75)}</span>
-            <span>{fmt(duration)}</span>
-         </div>
-
+         {/* Readout */}
          <div className='text-center text-xs text-gray-300'>
-            Snippet:{' '}
             <span className='tabular-nums'>
-               {fmt(startSec)} → {fmt(startSec + clipLen)}
+               {fmt(start)} → {fmt(start + clipLen)}
             </span>{' '}
             · {Math.round(clipLen)}s
          </div>
@@ -220,7 +261,7 @@ const SnippetPicker = ({
             </button>
             <button
                type='button'
-               onClick={() => onConfirm(startSec)}
+               onClick={() => onConfirm(start)}
                disabled={loading || !!error || clipping}
                className='flex-1 py-2 rounded-lg bg-purple-500 hover:bg-purple-400 disabled:opacity-50 text-white font-semibold text-sm'
             >

--- a/src/components/Admin/SnippetPicker.jsx
+++ b/src/components/Admin/SnippetPicker.jsx
@@ -8,7 +8,7 @@ const BARS_PER_SEC = 6;
 
 const clamp = (v, lo, hi) => Math.max(lo, Math.min(hi, v));
 
-function fmt(s) {
+function fmtTime(s) {
    s = Math.max(0, Math.round(s || 0));
    const m = Math.floor(s / 60);
    const r = s % 60;
@@ -25,8 +25,8 @@ const SnippetPicker = ({
    onConfirm,
    onBack,
 }) => {
-   // Resolution for the zoomed waveform — finer than the old 64 bars.
-   // Derived from the prepared durationSec so it's known before decode.
+   // Number of waveform bars, scaled to track length (from the prepared
+   // durationSec so it's known before the audio decodes).
    const barCount = useMemo(
       () => clamp(Math.round((durationSec || 60) * BARS_PER_SEC), 64, 2000),
       [durationSec]
@@ -245,7 +245,7 @@ const SnippetPicker = ({
          {/* Readout */}
          <div className='text-center text-xs text-gray-300'>
             <span className='tabular-nums'>
-               {fmt(start)} → {fmt(start + clipLen)}
+               {fmtTime(start)} → {fmtTime(start + clipLen)}
             </span>{' '}
             · {Math.round(clipLen)}s
          </div>

--- a/src/components/Admin/YouTubeFlow.jsx
+++ b/src/components/Admin/YouTubeFlow.jsx
@@ -1,7 +1,9 @@
 'use client';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import SnippetPicker from './SnippetPicker';
-import { parseYouTubeTitle, enrichFromDeezer } from './ytMetadata';
+import SearchStage from './youtube/SearchStage';
+import MetadataStage from './youtube/MetadataStage';
+import { parseYouTubeTitle } from './ytMetadata';
 
 const YouTubeFlow = ({ date, onSave }) => {
    // stage: 'search' | 'preparing' | 'picking' | 'metadata'
@@ -22,7 +24,6 @@ const YouTubeFlow = ({ date, onSave }) => {
       album: '',
       artwork_url: '',
    });
-   const [enriching, setEnriching] = useState(false);
    const [saving, setSaving] = useState(false);
 
    const debounceRef = useRef(null);
@@ -37,9 +38,8 @@ const YouTubeFlow = ({ date, onSave }) => {
       setSearching(true);
       setError(null);
       try {
-         const res = await fetch(
-            `/api/admin/music/yt/search?q=${encodeURIComponent(q)}`
-         );
+         const params = new URLSearchParams({ q });
+         const res = await fetch(`/api/admin/music/yt/search?${params}`);
          const json = await res.json().catch(() => ({}));
          if (id !== reqIdRef.current) return;
          if (!res.ok) {
@@ -127,29 +127,6 @@ const YouTubeFlow = ({ date, onSave }) => {
       }
    };
 
-   const enrich = async () => {
-      setEnriching(true);
-      setError(null);
-      try {
-         const found = await enrichFromDeezer({
-            title: meta.title,
-            artist: meta.artist,
-         });
-         if (found) {
-            setMeta((m) => ({
-               title: found.title || m.title,
-               artist: found.artist || m.artist,
-               album: found.album || m.album,
-               artwork_url: found.artwork_url || m.artwork_url,
-            }));
-         } else {
-            setError('No Deezer match found — keeping current details.');
-         }
-      } finally {
-         setEnriching(false);
-      }
-   };
-
    const save = async () => {
       if (!snippet) return;
       setSaving(true);
@@ -186,63 +163,34 @@ const YouTubeFlow = ({ date, onSave }) => {
       }
    };
 
-   const setMetaField = (field) => (e) =>
-      setMeta((m) => ({ ...m, [field]: e.target.value }));
+   const applyMatch = (match) =>
+      setMeta((m) => ({
+         title: match.title || m.title,
+         artist: match.artist || m.artist,
+         album: match.album || m.album,
+         artwork_url: match.artwork_url || m.artwork_url,
+      }));
 
    return (
       <div className='flex flex-col gap-3 flex-1 min-h-0'>
          {error && <p className='text-sm text-red-400 text-center'>{error}</p>}
 
          {stage === 'search' && (
-            <>
-               <input
-                  type='text'
-                  placeholder='Search YouTube…'
-                  value={query}
-                  onChange={(e) => setQuery(e.target.value)}
-                  className='w-full bg-[#1a1a1a] border border-[#303030] rounded-lg px-4 py-2 text-sm focus:outline-none focus:border-purple-500 transition-colors'
-                  autoFocus
-               />
-               <div className='overflow-y-auto flex-1 min-h-0 flex flex-col gap-2'>
-                  {searching && (
-                     <p className='text-center text-gray-500 text-sm py-4'>
-                        Searching…
-                     </p>
-                  )}
-                  {!searching && results.length === 0 && query.trim() && (
-                     <p className='text-center text-gray-500 text-sm py-4'>
-                        No results found.
-                     </p>
-                  )}
-                  {results.map((r) => (
-                     <button
-                        key={r.videoId}
-                        onClick={() => pick(r)}
-                        className='flex items-center gap-3 p-2 rounded-lg bg-[#1a1a1a] hover:bg-[#242424] transition-colors text-left'
-                     >
-                        <img
-                           src={r.thumbnail}
-                           alt={r.title}
-                           className='w-16 h-12 rounded object-cover flex-shrink-0'
-                        />
-                        <div className='flex-1 min-w-0'>
-                           <p className='text-sm font-medium truncate'>
-                              {r.title}
-                           </p>
-                           <p className='text-xs text-gray-500 truncate'>
-                              {r.channel}
-                           </p>
-                        </div>
-                     </button>
-                  ))}
-               </div>
-            </>
+            <SearchStage
+               query={query}
+               onQueryChange={setQuery}
+               searching={searching}
+               results={results}
+               onPick={pick}
+            />
          )}
 
          {stage === 'preparing' && (
             <div className='flex-1 flex flex-col items-center justify-center gap-3 text-gray-400'>
                <div className='w-8 h-8 border-2 border-purple-500 border-t-transparent rounded-full animate-spin' />
-               <p className='text-sm'>Downloading audio… (waking up service if asleep)</p>
+               <p className='text-sm'>
+                  Downloading audio… (waking up service if asleep)
+               </p>
             </div>
          )}
 
@@ -260,76 +208,16 @@ const YouTubeFlow = ({ date, onSave }) => {
          )}
 
          {stage === 'metadata' && (
-            <div className='flex flex-col gap-3 overflow-y-auto flex-1 min-h-0'>
-               <div className='flex items-center gap-3'>
-                  {meta.artwork_url && (
-                     <img
-                        src={meta.artwork_url}
-                        alt={meta.title}
-                        className='w-14 h-14 rounded object-cover flex-shrink-0'
-                     />
-                  )}
-                  <p className='text-xs text-purple-400'>
-                     15s snippet ready · confirm the details
-                  </p>
-               </div>
-
-               <label className='text-xs text-gray-400'>
-                  Title
-                  <input
-                     type='text'
-                     value={meta.title}
-                     onChange={setMetaField('title')}
-                     className='mt-1 w-full bg-[#1a1a1a] border border-[#303030] rounded-lg px-3 py-2 text-sm focus:outline-none focus:border-purple-500'
-                  />
-               </label>
-               <label className='text-xs text-gray-400'>
-                  Artist
-                  <input
-                     type='text'
-                     value={meta.artist}
-                     onChange={setMetaField('artist')}
-                     className='mt-1 w-full bg-[#1a1a1a] border border-[#303030] rounded-lg px-3 py-2 text-sm focus:outline-none focus:border-purple-500'
-                  />
-               </label>
-               <label className='text-xs text-gray-400'>
-                  Album (optional)
-                  <input
-                     type='text'
-                     value={meta.album}
-                     onChange={setMetaField('album')}
-                     className='mt-1 w-full bg-[#1a1a1a] border border-[#303030] rounded-lg px-3 py-2 text-sm focus:outline-none focus:border-purple-500'
-                  />
-               </label>
-               <label className='text-xs text-gray-400'>
-                  Artwork URL
-                  <input
-                     type='text'
-                     value={meta.artwork_url}
-                     onChange={setMetaField('artwork_url')}
-                     className='mt-1 w-full bg-[#1a1a1a] border border-[#303030] rounded-lg px-3 py-2 text-sm focus:outline-none focus:border-purple-500'
-                  />
-               </label>
-
-               <div className='flex gap-2 pt-1'>
-                  <button
-                     type='button'
-                     onClick={enrich}
-                     disabled={enriching}
-                     className='px-4 py-2 rounded-lg bg-[#1a1a1a] border border-[#303030] text-sm text-gray-300 hover:text-white disabled:opacity-50'
-                  >
-                     {enriching ? 'Enriching…' : 'Enrich via Deezer'}
-                  </button>
-                  <button
-                     type='button'
-                     onClick={save}
-                     disabled={saving || !meta.title || !meta.artist}
-                     className='flex-1 py-2 rounded-lg bg-purple-500 hover:bg-purple-400 disabled:opacity-50 text-white font-semibold text-sm'
-                  >
-                     {saving ? 'Saving…' : 'Save song of the day'}
-                  </button>
-               </div>
-            </div>
+            <MetadataStage
+               meta={meta}
+               onChangeField={(field, value) =>
+                  setMeta((m) => ({ ...m, [field]: value }))
+               }
+               onApplyMatch={applyMatch}
+               defaultQuery={`${meta.artist} ${meta.title}`.trim()}
+               saving={saving}
+               onSave={save}
+            />
          )}
       </div>
    );

--- a/src/components/Admin/YouTubeFlow.jsx
+++ b/src/components/Admin/YouTubeFlow.jsx
@@ -1,0 +1,338 @@
+'use client';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import SnippetPicker from './SnippetPicker';
+import { parseYouTubeTitle, enrichFromDeezer } from './ytMetadata';
+
+const YouTubeFlow = ({ date, onSave }) => {
+   // stage: 'search' | 'preparing' | 'picking' | 'metadata'
+   const [stage, setStage] = useState('search');
+   const [query, setQuery] = useState('');
+   const [results, setResults] = useState([]);
+   const [searching, setSearching] = useState(false);
+   const [error, setError] = useState(null);
+
+   const [selected, setSelected] = useState(null); // chosen search result
+   const [job, setJob] = useState(null); // prepare response
+   const [clipping, setClipping] = useState(false);
+   const [snippet, setSnippet] = useState(null); // { snippet_url, startSec }
+
+   const [meta, setMeta] = useState({
+      title: '',
+      artist: '',
+      album: '',
+      artwork_url: '',
+   });
+   const [enriching, setEnriching] = useState(false);
+   const [saving, setSaving] = useState(false);
+
+   const debounceRef = useRef(null);
+   const reqIdRef = useRef(0);
+
+   const runSearch = useCallback(async (q) => {
+      if (!q.trim()) {
+         setResults([]);
+         return;
+      }
+      const id = ++reqIdRef.current;
+      setSearching(true);
+      setError(null);
+      try {
+         const res = await fetch(
+            `/api/admin/music/yt/search?q=${encodeURIComponent(q)}`
+         );
+         const json = await res.json().catch(() => ({}));
+         if (id !== reqIdRef.current) return;
+         if (!res.ok) {
+            setError(json.error || 'Search failed');
+            setResults([]);
+            return;
+         }
+         setResults(json.results || []);
+      } catch {
+         if (id === reqIdRef.current) setError('Network error during search');
+      } finally {
+         if (id === reqIdRef.current) setSearching(false);
+      }
+   }, []);
+
+   useEffect(() => {
+      clearTimeout(debounceRef.current);
+      debounceRef.current = setTimeout(() => runSearch(query), 400);
+      return () => clearTimeout(debounceRef.current);
+   }, [query, runSearch]);
+
+   const pick = async (item) => {
+      setSelected(item);
+      setStage('preparing');
+      setError(null);
+      try {
+         const res = await fetch('/api/admin/music/yt/prepare', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ videoId: item.videoId }),
+         });
+         const json = await res.json().catch(() => ({}));
+         if (!res.ok) {
+            setError(json.error || 'Failed to prepare audio');
+            setStage('search');
+            return;
+         }
+         setJob(json);
+         setStage('picking');
+      } catch {
+         setError('Network error while preparing audio');
+         setStage('search');
+      }
+   };
+
+   const confirmSnippet = async (startSec) => {
+      if (!job) return;
+      setClipping(true);
+      setError(null);
+      try {
+         const res = await fetch('/api/admin/music/yt/clip', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ jobId: job.jobId, startSec }),
+         });
+         const json = await res.json().catch(() => ({}));
+         if (!res.ok) {
+            if (res.status === 410) {
+               setError('Clip session expired — please pick the song again.');
+               setStage('search');
+            } else {
+               setError(json.error || 'Failed to create snippet');
+            }
+            return;
+         }
+         setSnippet({
+            snippet_url: json.snippet_url,
+            startSec: json.startSec ?? startSec,
+         });
+         const parsed = parseYouTubeTitle(
+            job.title || selected?.title,
+            job.channel || selected?.channel
+         );
+         setMeta({
+            title: parsed.title || '',
+            artist: parsed.artist || '',
+            album: '',
+            artwork_url: job.thumbnail || selected?.thumbnail || '',
+         });
+         setStage('metadata');
+      } catch {
+         setError('Network error while creating snippet');
+      } finally {
+         setClipping(false);
+      }
+   };
+
+   const enrich = async () => {
+      setEnriching(true);
+      setError(null);
+      try {
+         const found = await enrichFromDeezer({
+            title: meta.title,
+            artist: meta.artist,
+         });
+         if (found) {
+            setMeta((m) => ({
+               title: found.title || m.title,
+               artist: found.artist || m.artist,
+               album: found.album || m.album,
+               artwork_url: found.artwork_url || m.artwork_url,
+            }));
+         } else {
+            setError('No Deezer match found — keeping current details.');
+         }
+      } finally {
+         setEnriching(false);
+      }
+   };
+
+   const save = async () => {
+      if (!snippet) return;
+      setSaving(true);
+      setError(null);
+      try {
+         const res = await fetch('/api/admin/music', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+               date,
+               source: 'youtube',
+               snippet_url: snippet.snippet_url,
+               snippet_start_sec: snippet.startSec,
+               youtube_id: selected?.videoId || null,
+               title: meta.title,
+               artist: meta.artist,
+               album: meta.album,
+               artwork_url: meta.artwork_url,
+               track_url: selected?.videoId
+                  ? `https://www.youtube.com/watch?v=${selected.videoId}`
+                  : null,
+            }),
+         });
+         const json = await res.json().catch(() => ({}));
+         if (!res.ok) {
+            setError(json.error || 'Failed to save song');
+            return;
+         }
+         if (json.song) onSave(json.song);
+      } catch {
+         setError('Network error while saving');
+      } finally {
+         setSaving(false);
+      }
+   };
+
+   const setMetaField = (field) => (e) =>
+      setMeta((m) => ({ ...m, [field]: e.target.value }));
+
+   return (
+      <div className='flex flex-col gap-3 flex-1 min-h-0'>
+         {error && <p className='text-sm text-red-400 text-center'>{error}</p>}
+
+         {stage === 'search' && (
+            <>
+               <input
+                  type='text'
+                  placeholder='Search YouTube…'
+                  value={query}
+                  onChange={(e) => setQuery(e.target.value)}
+                  className='w-full bg-[#1a1a1a] border border-[#303030] rounded-lg px-4 py-2 text-sm focus:outline-none focus:border-purple-500 transition-colors'
+                  autoFocus
+               />
+               <div className='overflow-y-auto flex-1 min-h-0 flex flex-col gap-2'>
+                  {searching && (
+                     <p className='text-center text-gray-500 text-sm py-4'>
+                        Searching…
+                     </p>
+                  )}
+                  {!searching && results.length === 0 && query.trim() && (
+                     <p className='text-center text-gray-500 text-sm py-4'>
+                        No results found.
+                     </p>
+                  )}
+                  {results.map((r) => (
+                     <button
+                        key={r.videoId}
+                        onClick={() => pick(r)}
+                        className='flex items-center gap-3 p-2 rounded-lg bg-[#1a1a1a] hover:bg-[#242424] transition-colors text-left'
+                     >
+                        <img
+                           src={r.thumbnail}
+                           alt={r.title}
+                           className='w-16 h-12 rounded object-cover flex-shrink-0'
+                        />
+                        <div className='flex-1 min-w-0'>
+                           <p className='text-sm font-medium truncate'>
+                              {r.title}
+                           </p>
+                           <p className='text-xs text-gray-500 truncate'>
+                              {r.channel}
+                           </p>
+                        </div>
+                     </button>
+                  ))}
+               </div>
+            </>
+         )}
+
+         {stage === 'preparing' && (
+            <div className='flex-1 flex flex-col items-center justify-center gap-3 text-gray-400'>
+               <div className='w-8 h-8 border-2 border-purple-500 border-t-transparent rounded-full animate-spin' />
+               <p className='text-sm'>Downloading audio… (waking up service if asleep)</p>
+            </div>
+         )}
+
+         {stage === 'picking' && job && (
+            <SnippetPicker
+               audioUrl={`/api/admin/music/yt/audio/${job.jobId}`}
+               durationSec={job.durationSec}
+               title={job.title || selected?.title}
+               channel={job.channel || selected?.channel}
+               thumbnail={job.thumbnail || selected?.thumbnail}
+               clipping={clipping}
+               onConfirm={confirmSnippet}
+               onBack={() => setStage('search')}
+            />
+         )}
+
+         {stage === 'metadata' && (
+            <div className='flex flex-col gap-3 overflow-y-auto flex-1 min-h-0'>
+               <div className='flex items-center gap-3'>
+                  {meta.artwork_url && (
+                     <img
+                        src={meta.artwork_url}
+                        alt={meta.title}
+                        className='w-14 h-14 rounded object-cover flex-shrink-0'
+                     />
+                  )}
+                  <p className='text-xs text-purple-400'>
+                     15s snippet ready · confirm the details
+                  </p>
+               </div>
+
+               <label className='text-xs text-gray-400'>
+                  Title
+                  <input
+                     type='text'
+                     value={meta.title}
+                     onChange={setMetaField('title')}
+                     className='mt-1 w-full bg-[#1a1a1a] border border-[#303030] rounded-lg px-3 py-2 text-sm focus:outline-none focus:border-purple-500'
+                  />
+               </label>
+               <label className='text-xs text-gray-400'>
+                  Artist
+                  <input
+                     type='text'
+                     value={meta.artist}
+                     onChange={setMetaField('artist')}
+                     className='mt-1 w-full bg-[#1a1a1a] border border-[#303030] rounded-lg px-3 py-2 text-sm focus:outline-none focus:border-purple-500'
+                  />
+               </label>
+               <label className='text-xs text-gray-400'>
+                  Album (optional)
+                  <input
+                     type='text'
+                     value={meta.album}
+                     onChange={setMetaField('album')}
+                     className='mt-1 w-full bg-[#1a1a1a] border border-[#303030] rounded-lg px-3 py-2 text-sm focus:outline-none focus:border-purple-500'
+                  />
+               </label>
+               <label className='text-xs text-gray-400'>
+                  Artwork URL
+                  <input
+                     type='text'
+                     value={meta.artwork_url}
+                     onChange={setMetaField('artwork_url')}
+                     className='mt-1 w-full bg-[#1a1a1a] border border-[#303030] rounded-lg px-3 py-2 text-sm focus:outline-none focus:border-purple-500'
+                  />
+               </label>
+
+               <div className='flex gap-2 pt-1'>
+                  <button
+                     type='button'
+                     onClick={enrich}
+                     disabled={enriching}
+                     className='px-4 py-2 rounded-lg bg-[#1a1a1a] border border-[#303030] text-sm text-gray-300 hover:text-white disabled:opacity-50'
+                  >
+                     {enriching ? 'Enriching…' : 'Enrich via Deezer'}
+                  </button>
+                  <button
+                     type='button'
+                     onClick={save}
+                     disabled={saving || !meta.title || !meta.artist}
+                     className='flex-1 py-2 rounded-lg bg-purple-500 hover:bg-purple-400 disabled:opacity-50 text-white font-semibold text-sm'
+                  >
+                     {saving ? 'Saving…' : 'Save song of the day'}
+                  </button>
+               </div>
+            </div>
+         )}
+      </div>
+   );
+};
+
+export default YouTubeFlow;

--- a/src/components/Admin/useWaveform.js
+++ b/src/components/Admin/useWaveform.js
@@ -1,0 +1,67 @@
+import { useEffect, useState } from 'react';
+
+// Fetches an audio URL, decodes it with the Web Audio API, and returns
+// normalized peak heights (0..1) plus the true duration.
+export default function useWaveform(audioUrl, barCount = 64) {
+   const [state, setState] = useState({
+      peaks: [],
+      duration: 0,
+      loading: true,
+      error: null,
+   });
+
+   useEffect(() => {
+      if (!audioUrl) return;
+      let cancelled = false;
+      let ctx;
+      setState({ peaks: [], duration: 0, loading: true, error: null });
+
+      (async () => {
+         try {
+            const res = await fetch(audioUrl);
+            if (!res.ok) throw new Error('Failed to load audio');
+            const raw = await res.arrayBuffer();
+            const Ctx = window.AudioContext || window.webkitAudioContext;
+            ctx = new Ctx();
+            const audioBuf = await ctx.decodeAudioData(raw);
+            const data = audioBuf.getChannelData(0);
+            const block = Math.max(1, Math.floor(data.length / barCount));
+            const peaks = [];
+            for (let i = 0; i < barCount; i++) {
+               let sum = 0;
+               for (let j = 0; j < block; j++) {
+                  sum += Math.abs(data[i * block + j] || 0);
+               }
+               peaks.push(sum / block);
+            }
+            const max = Math.max(...peaks, 0.0001);
+            const normalized = peaks.map((p) => p / max);
+            if (!cancelled) {
+               setState({
+                  peaks: normalized,
+                  duration: audioBuf.duration,
+                  loading: false,
+                  error: null,
+               });
+            }
+         } catch (err) {
+            if (!cancelled) {
+               setState({
+                  peaks: [],
+                  duration: 0,
+                  loading: false,
+                  error: err.message || 'Could not analyze audio',
+               });
+            }
+         } finally {
+            if (ctx) ctx.close().catch(() => {});
+         }
+      })();
+
+      return () => {
+         cancelled = true;
+      };
+   }, [audioUrl, barCount]);
+
+   return state;
+}

--- a/src/components/Admin/youtube/MetadataStage.jsx
+++ b/src/components/Admin/youtube/MetadataStage.jsx
@@ -1,0 +1,161 @@
+'use client';
+import React, { useEffect, useRef, useState } from 'react';
+import { searchDeezer } from '../ytMetadata';
+
+const fieldClass =
+   'mt-1 w-full bg-[#1a1a1a] border border-[#303030] rounded-lg px-3 py-2 text-sm focus:outline-none focus:border-purple-500';
+
+// Metadata confirmation stage: editable title/artist/album/artwork fields plus
+// a Deezer enrichment search where the user picks a match to fill clean
+// metadata. Owns its own Deezer search state; reports edits/picks/save upward.
+const MetadataStage = ({
+   meta,
+   onChangeField,
+   onApplyMatch,
+   defaultQuery,
+   saving,
+   onSave,
+}) => {
+   const [query, setQuery] = useState(defaultQuery || '');
+   const [results, setResults] = useState([]);
+   const [searching, setSearching] = useState(false);
+   const [touched, setTouched] = useState(false);
+   const debounceRef = useRef(null);
+   const reqIdRef = useRef(0);
+
+   // Debounced Deezer search — only after the user engages the field, so we
+   // don't fire an automatic query the moment the stage mounts.
+   useEffect(() => {
+      if (!touched) return;
+      clearTimeout(debounceRef.current);
+      debounceRef.current = setTimeout(async () => {
+         const id = ++reqIdRef.current;
+         setSearching(true);
+         try {
+            const found = await searchDeezer(query);
+            if (id === reqIdRef.current) setResults(found);
+         } finally {
+            if (id === reqIdRef.current) setSearching(false);
+         }
+      }, 400);
+      return () => clearTimeout(debounceRef.current);
+   }, [query, touched]);
+
+   const canSave = !!meta.title && !!meta.artist && !saving;
+
+   return (
+      <div className='flex flex-col gap-3 overflow-y-auto flex-1 min-h-0'>
+         <div className='flex items-center gap-3'>
+            {meta.artwork_url && (
+               <img
+                  src={meta.artwork_url}
+                  alt={meta.title}
+                  className='w-14 h-14 rounded object-cover flex-shrink-0'
+               />
+            )}
+            <p className='text-xs text-purple-400'>
+               15s snippet ready · confirm the details
+            </p>
+         </div>
+
+         <label className='text-xs text-gray-400'>
+            Title
+            <input
+               type='text'
+               value={meta.title}
+               onChange={(e) => onChangeField('title', e.target.value)}
+               className={fieldClass}
+            />
+         </label>
+         <label className='text-xs text-gray-400'>
+            Artist
+            <input
+               type='text'
+               value={meta.artist}
+               onChange={(e) => onChangeField('artist', e.target.value)}
+               className={fieldClass}
+            />
+         </label>
+         <label className='text-xs text-gray-400'>
+            Album (optional)
+            <input
+               type='text'
+               value={meta.album}
+               onChange={(e) => onChangeField('album', e.target.value)}
+               className={fieldClass}
+            />
+         </label>
+         <label className='text-xs text-gray-400'>
+            Artwork URL
+            <input
+               type='text'
+               value={meta.artwork_url}
+               onChange={(e) => onChangeField('artwork_url', e.target.value)}
+               className={fieldClass}
+            />
+         </label>
+
+         {/* Deezer enrichment: search + pick a match to fill clean metadata */}
+         <div className='flex flex-col gap-2 pt-2 border-t border-[#242424]'>
+            <label className='text-xs text-gray-400'>
+               Enrich via Deezer — search and pick a match
+               <input
+                  type='text'
+                  value={query}
+                  placeholder='e.g. artist + song title'
+                  onChange={(e) => {
+                     setQuery(e.target.value);
+                     setTouched(true);
+                  }}
+                  onFocus={() => setTouched(true)}
+                  className={fieldClass}
+               />
+            </label>
+            {searching && (
+               <p className='text-xs text-gray-500'>Searching Deezer…</p>
+            )}
+            {!searching && touched && query.trim() && results.length === 0 && (
+               <p className='text-xs text-gray-500'>No Deezer matches.</p>
+            )}
+            {results.length > 0 && (
+               <div className='max-h-40 overflow-y-auto flex flex-col gap-1'>
+                  {results.map((r) => (
+                     <button
+                        key={r.id}
+                        type='button'
+                        onClick={() => onApplyMatch(r)}
+                        className='flex items-center gap-2 p-2 rounded-lg bg-[#1a1a1a] hover:bg-[#242424] transition-colors text-left'
+                     >
+                        <img
+                           src={r.artwork_url}
+                           alt={r.title}
+                           className='w-9 h-9 rounded object-cover flex-shrink-0'
+                        />
+                        <div className='flex-1 min-w-0'>
+                           <p className='text-xs font-medium truncate'>
+                              {r.title}
+                           </p>
+                           <p className='text-[11px] text-gray-500 truncate'>
+                              {r.artist}
+                              {r.album ? ` · ${r.album}` : ''}
+                           </p>
+                        </div>
+                     </button>
+                  ))}
+               </div>
+            )}
+         </div>
+
+         <button
+            type='button'
+            onClick={onSave}
+            disabled={!canSave}
+            className='py-2 rounded-lg bg-purple-500 hover:bg-purple-400 disabled:opacity-50 text-white font-semibold text-sm'
+         >
+            {saving ? 'Saving…' : 'Save song of the day'}
+         </button>
+      </div>
+   );
+};
+
+export default MetadataStage;

--- a/src/components/Admin/youtube/SearchStage.jsx
+++ b/src/components/Admin/youtube/SearchStage.jsx
@@ -1,0 +1,47 @@
+'use client';
+import React from 'react';
+
+// YouTube search stage: query input + results list. Stateless — the parent
+// owns the query/results and handles selection.
+const SearchStage = ({ query, onQueryChange, searching, results, onPick }) => (
+   <>
+      <input
+         type='text'
+         placeholder='Search YouTube…'
+         value={query}
+         onChange={(e) => onQueryChange(e.target.value)}
+         className='w-full bg-[#1a1a1a] border border-[#303030] rounded-lg px-4 py-2 text-sm focus:outline-none focus:border-purple-500 transition-colors'
+         autoFocus
+      />
+      <div className='overflow-y-auto flex-1 min-h-0 flex flex-col gap-2'>
+         {searching && (
+            <p className='text-center text-gray-500 text-sm py-4'>Searching…</p>
+         )}
+         {!searching && results.length === 0 && query.trim() && (
+            <p className='text-center text-gray-500 text-sm py-4'>
+               No results found.
+            </p>
+         )}
+         {results.map((r) => (
+            <button
+               key={r.videoId}
+               type='button'
+               onClick={() => onPick(r)}
+               className='flex items-center gap-3 p-2 rounded-lg bg-[#1a1a1a] hover:bg-[#242424] transition-colors text-left'
+            >
+               <img
+                  src={r.thumbnail}
+                  alt={r.title}
+                  className='w-16 h-12 rounded object-cover flex-shrink-0'
+               />
+               <div className='flex-1 min-w-0'>
+                  <p className='text-sm font-medium truncate'>{r.title}</p>
+                  <p className='text-xs text-gray-500 truncate'>{r.channel}</p>
+               </div>
+            </button>
+         ))}
+      </div>
+   </>
+);
+
+export default SearchStage;

--- a/src/components/Admin/ytMetadata.js
+++ b/src/components/Admin/ytMetadata.js
@@ -1,0 +1,43 @@
+// Best-effort parse of a YouTube video title into { title, artist }.
+export function parseYouTubeTitle(rawTitle, channel = '') {
+   let t = (rawTitle || '').trim();
+
+   // Drop bracketed/parenthesized noise like (Official Video), [4K], (Lyrics)
+   t = t
+      .replace(
+         /[\(\[][^)\]]*(official|video|audio|lyric|lyrics|hd|4k|mv|m\/v|visualizer|remaster(ed)?)[^)\]]*[\)\]]/gi,
+         ''
+      )
+      .trim();
+   // Drop trailing "- Official ...", "| Lyrics", etc.
+   t = t.replace(/\s*[-–—|]\s*(official.*|lyric.*|audio.*)$/i, '').trim();
+
+   // "Artist - Title" pattern
+   const dash = t.split(/\s+[-–—]\s+/);
+   if (dash.length >= 2) {
+      return { artist: dash[0].trim(), title: dash.slice(1).join(' - ').trim() };
+   }
+
+   // Fallback: channel as artist (strip a trailing "- Topic")
+   const artist = (channel || '').replace(/\s*-\s*topic$/i, '').trim();
+   return { artist, title: t };
+}
+
+// Look up clean metadata via the existing Deezer search proxy.
+// Returns the top match or null.
+export async function enrichFromDeezer({ title, artist }) {
+   const params = new URLSearchParams();
+   if (title) params.set('q', title);
+   if (artist) params.set('artist', artist);
+   const res = await fetch(`/api/admin/music/search?${params}`);
+   if (!res.ok) return null;
+   const json = await res.json().catch(() => ({}));
+   const top = (json.results || [])[0];
+   if (!top) return null;
+   return {
+      title: top.title,
+      artist: top.artist,
+      album: top.album,
+      artwork_url: top.artwork_url,
+   };
+}

--- a/src/components/Admin/ytMetadata.js
+++ b/src/components/Admin/ytMetadata.js
@@ -23,21 +23,14 @@ export function parseYouTubeTitle(rawTitle, channel = '') {
    return { artist, title: t };
 }
 
-// Look up clean metadata via the existing Deezer search proxy.
-// Returns the top match or null.
-export async function enrichFromDeezer({ title, artist }) {
-   const params = new URLSearchParams();
-   if (title) params.set('q', title);
-   if (artist) params.set('artist', artist);
+// Free-form Deezer search for the enrichment picker. Returns the results list
+// ([{ id, title, artist, album, artwork_url, ... }]) so the user can pick a match.
+export async function searchDeezer(query) {
+   const q = (query || '').trim();
+   if (!q) return [];
+   const params = new URLSearchParams({ q, scope: 'all' });
    const res = await fetch(`/api/admin/music/search?${params}`);
-   if (!res.ok) return null;
+   if (!res.ok) return [];
    const json = await res.json().catch(() => ({}));
-   const top = (json.results || [])[0];
-   if (!top) return null;
-   return {
-      title: top.title,
-      artist: top.artist,
-      album: top.album,
-      artwork_url: top.artwork_url,
-   };
+   return json.results || [];
 }

--- a/src/components/Home/SongOfTheDayComponent.js
+++ b/src/components/Home/SongOfTheDayComponent.js
@@ -101,10 +101,15 @@ const SongOfTheDayComponent = () => {
             <SongOfTheDaySkeleton />
          ) : (
             <div className='w-full h-full flex pl-3 pr-2 gap-x-2 items-center'>
-               <div className='relative min-w-[7rem] min-h-[7rem]'>
-                  <a target='_blank' rel='noreferrer' href={safeTrackUrl}>
+               <div className='relative w-28 h-28 flex-shrink-0 rounded-md overflow-hidden'>
+                  <a
+                     target='_blank'
+                     rel='noreferrer'
+                     href={safeTrackUrl}
+                     className='block w-full h-full'
+                  >
                      <Image
-                        className='w-28 h-28'
+                        className='w-full h-full object-cover'
                         width={200}
                         height={200}
                         alt={song?.title ?? 'No song picked yet'}

--- a/src/components/Home/SongOfTheDayComponent.js
+++ b/src/components/Home/SongOfTheDayComponent.js
@@ -41,8 +41,11 @@ const SongOfTheDayComponent = () => {
          .then(async (json) => {
             if (!json.date) return;
             setSong(json);
-            // Resolve preview URL dynamically if deezer_id is present
-            if (json.deezer_id) {
+            if (json.snippet_url) {
+               // YouTube snippet: play the stored clip directly.
+               setSong((prev) => ({ ...prev, preview_url: json.snippet_url }));
+               preload(json.snippet_url);
+            } else if (json.deezer_id) {
                try {
                   const res = await fetch(`/api/music/preview?ids=${json.deezer_id}`);
                   const data = await res.json();
@@ -60,7 +63,7 @@ const SongOfTheDayComponent = () => {
                // Legacy fallback for songs without deezer_id
                preload(json.preview_url);
             } else {
-               console.warn('[SongOfTheDay] No deezer_id or preview_url — play unavailable');
+               console.warn('[SongOfTheDay] No snippet_url, deezer_id, or preview_url — play unavailable');
             }
          })
          .catch((err) => console.error('SongOfTheDay fetch failed', err))

--- a/src/lib/musicDl.js
+++ b/src/lib/musicDl.js
@@ -1,10 +1,12 @@
 // Authenticated fetch wrapper to the music-dl-service.
 // Env is read per-call so route handlers fail clearly if it's unset.
 function musicDlConfig() {
-   const baseUrl = process.env.MUSIC_DL_URL;
+   const baseUrl = process.env.MUSIC_DL_SERVICE_URL;
    const apiKey = process.env.MUSIC_DL_API_KEY;
    if (!baseUrl || !apiKey) {
-      throw new Error('MUSIC_DL_URL and MUSIC_DL_API_KEY env vars are required');
+      throw new Error(
+         'MUSIC_DL_SERVICE_URL and MUSIC_DL_API_KEY env vars are required'
+      );
    }
    return { baseUrl: baseUrl.replace(/\/$/, ''), apiKey };
 }

--- a/src/lib/musicDl.js
+++ b/src/lib/musicDl.js
@@ -11,13 +11,27 @@ function musicDlConfig() {
    return { baseUrl: baseUrl.replace(/\/$/, ''), apiKey };
 }
 
+// `init.params` (a plain object) is serialized + URL-encoded onto the query
+// string here, so callers never hand-concatenate/encode query params.
 export async function musicDlFetch(path, init = {}) {
    const { baseUrl, apiKey } = musicDlConfig();
-   return fetch(`${baseUrl}${path}`, {
-      ...init,
+   const { params, headers, ...rest } = init;
+
+   let url = `${baseUrl}${path}`;
+   if (params && typeof params === 'object') {
+      const qs = new URLSearchParams();
+      for (const [key, value] of Object.entries(params)) {
+         if (value !== undefined && value !== null) qs.set(key, String(value));
+      }
+      const query = qs.toString();
+      if (query) url += (url.includes('?') ? '&' : '?') + query;
+   }
+
+   return fetch(url, {
+      ...rest,
       headers: {
          Authorization: `Bearer ${apiKey}`,
-         ...(init.headers || {}),
+         ...(headers || {}),
       },
       cache: 'no-store',
    });

--- a/src/lib/musicDl.js
+++ b/src/lib/musicDl.js
@@ -1,0 +1,22 @@
+// Authenticated fetch wrapper to the music-dl-service.
+// Env is read per-call so route handlers fail clearly if it's unset.
+function musicDlConfig() {
+   const baseUrl = process.env.MUSIC_DL_URL;
+   const apiKey = process.env.MUSIC_DL_API_KEY;
+   if (!baseUrl || !apiKey) {
+      throw new Error('MUSIC_DL_URL and MUSIC_DL_API_KEY env vars are required');
+   }
+   return { baseUrl: baseUrl.replace(/\/$/, ''), apiKey };
+}
+
+export async function musicDlFetch(path, init = {}) {
+   const { baseUrl, apiKey } = musicDlConfig();
+   return fetch(`${baseUrl}${path}`, {
+      ...init,
+      headers: {
+         Authorization: `Bearer ${apiKey}`,
+         ...(init.headers || {}),
+      },
+      cache: 'no-store',
+   });
+}

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -6,6 +6,12 @@ export async function middleware(req) {
    const supabase = createMiddlewareClient({ req, res });
    const session = await supabase.auth.getSession();
    if (!session?.data?.session) {
+      // API routes (every matched API path is /api/admin/*) return a real 401
+      // so fetch clients get a clean error instead of transparently following a
+      // redirect to the login HTML. Page routes keep redirecting to /login.
+      if (req.nextUrl.pathname.startsWith('/api/')) {
+         return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+      }
       const loginURL = new URL('/login', req.url);
       loginURL.searchParams.set('redirectedFrom', req.nextUrl.pathname);
       loginURL.searchParams.set(


### PR DESCRIPTION
## Summary

Adds a YouTube source for the admin "song of the day", with a 15-second snippet picker, the ability to clear a day, and an Instagram-style zoomed picker. The full song never persists — it lives only in the `music-dl-service`'s RAM during picking; only the chosen 15s clip is stored and served.

**Three features (each spec'd + planned under `docs/superpowers/`):**

1. **YouTube snippet picker** — Deezer|YouTube toggle in the song modal; search YouTube → service downloads to RAM → scrub a 15s window over a waveform → service trims + uploads only the snippet to Supabase → calendar + homepage widget play the stored clip. Metadata auto-filled from the YouTube title with an optional "Enrich via Deezer".
2. **Clear song of the day** — inline-confirm Remove control; `DELETE /api/admin/music?date=` deletes the row and best-effort-cascades to the service to delete the stored snippet.
3. **Zoomed picker + fix** — rewrote the picker to a seconds-scale waveform that scrolls under a fixed centered start marker (responsive zoom: 15s = center→right edge); fixed the modal closing when a drag is released outside it.

**Website-side only.** The `music-dl-service` endpoints (`GET /yt/search`, `POST /yt/prepare`, `GET /yt/audio/:jobId`, `POST /yt/clip`, `DELETE /yt/snippet`) are specified in `docs/superpowers/handoffs/` and implemented in that repo. New env: `MUSIC_DL_SERVICE_URL`, `MUSIC_DL_API_KEY`.

**DB migration required before merge/deploy:** `docs/superpowers/migrations/2026-06-14-song-of-the-day-youtube-snippets.sql` adds `source`, `snippet_url`, `youtube_id`, `snippet_start_sec` to `song_of_the_day` (additive, backward-compatible).

## Test Plan

- [ ] Apply the schema migration in Supabase.
- [ ] Set `MUSIC_DL_SERVICE_URL` + `MUSIC_DL_API_KEY`; confirm the service exposes the `/yt/*` + `DELETE /yt/snippet` endpoints.
- [ ] Deezer flow still works (search, pick, 30s preview on calendar + widget).
- [ ] YouTube flow: search → pick → scrub 15s (zoomed, centered start, scrolls; play loops with playhead) → save → plays the snippet on the calendar + homepage widget.
- [ ] Clear a YouTube day → row gone AND `snippets/<uuid>.mp3` removed from storage; clear a Deezer day → row gone, no service call; Cancel keeps the song.
- [ ] Service-down: clearing a YouTube day still clears the row (best-effort warning), and the picker recovers from an expired job (410).
- [ ] Dragging the waveform and releasing outside the modal does NOT close it.
- [ ] `npm run lint` + `npm run build` clean.

## Notes / follow-ups
- Known non-blocking: the picker fetches the audio twice (once for `<audio>`, once for the waveform decode) — easy optimization later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)